### PR TITLE
fix: Beckman Echo Plate Reformat - update measurement time to fill missing date with file date if needed

### DIFF
--- a/src/allotropy/parsers/beckman_echo_plate_reformat/beckman_echo_plate_reformat_structure.py
+++ b/src/allotropy/parsers/beckman_echo_plate_reformat/beckman_echo_plate_reformat_structure.py
@@ -1,3 +1,4 @@
+from functools import partial
 from pathlib import Path
 
 import pandas as pd
@@ -8,6 +9,7 @@ from allotropy.allotrope.schema_mappers.adm.liquid_handler.benchling._2024._11.l
     MeasurementGroup,
     Metadata,
 )
+from allotropy.exceptions import AllotropeConversionError
 from allotropy.parsers.beckman_echo_plate_reformat import constants
 from allotropy.parsers.constants import NOT_APPLICABLE
 from allotropy.parsers.utils.pandas import map_rows, SeriesData
@@ -36,7 +38,7 @@ def create_metadata(header_footer_data: SeriesData, file_path: str) -> Metadata:
     )
 
 
-def _create_measurement(row_data: SeriesData) -> Measurement:
+def _create_measurement(row_data: SeriesData, run_date_time: str | None) -> Measurement:
     def convert_echo_nl_to_ul(value: float | None) -> float | None:
         return (
             (value * constants.PLATE_REFORMAT_REPORT_VOLUME_CONVERSION_TO_UL)
@@ -44,9 +46,20 @@ def _create_measurement(row_data: SeriesData) -> Measurement:
             else None
         )
 
+    # If the Date Time Point only contains time (no date) combine with Run Date/Time to create measurement time.
+    # We detect if there is a date in the timestamp by checking for a space, and if there is no space, add the date
+    # component of
+    date_time_point = row_data[str, "Date Time Point"]
+    if " " not in date_time_point.strip():
+        if not run_date_time or " " not in run_date_time:
+            msg = "Cannot parse timestamp for measurement, 'Date Time Point' does not contain a date (time only) and there is no valid 'Run Date/Time' in the header to infer date from."
+            raise AllotropeConversionError(msg)
+        run_date_time_date = run_date_time.split(" ")
+        date_time_point = f"{run_date_time_date[0]} {date_time_point}"
+
     return Measurement(
         identifier=random_uuid_str(),
-        measurement_time=row_data[str, "Date Time Point"],
+        measurement_time=date_time_point,
         sample_identifier=row_data.get(str, "Sample ID", NOT_APPLICABLE),
         source_plate=row_data[str, "Source Plate Barcode"],
         source_well=row_data[str, "Source Well"],
@@ -92,15 +105,16 @@ def _create_measurement(row_data: SeriesData) -> Measurement:
 def create_measurement_groups(
     data: pd.DataFrame, header: SeriesData
 ) -> list[MeasurementGroup]:
-
+    run_date_time = header.get(str, "Run Date/Time")
+    create_measurement = partial(_create_measurement, run_date_time=run_date_time)
     return [
         MeasurementGroup(
             analyst=header[str, "User Name"],
             analytical_method_identifier=header.get(str, "Protocol Name"),
             experimental_data_identifier=header.get(str, "Run ID"),
-            measurements=map_rows(data, _create_measurement),
+            measurements=map_rows(data, create_measurement),
             custom_info={
-                "Run Date/Time": header.get(str, "Run Date/Time"),
+                "Run Date/Time": run_date_time,
             },
         )
     ]

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.json
@@ -45,7 +45,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_0",
-                            "measurement time": "2025-05-12T15:54:48+00:00",
+                            "measurement time": "2025-03-11T15:54:48+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -95,7 +95,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_1",
-                            "measurement time": "2025-05-12T15:55:00+00:00",
+                            "measurement time": "2025-03-11T15:55:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -145,7 +145,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_2",
-                            "measurement time": "2025-05-12T15:55:06+00:00",
+                            "measurement time": "2025-03-11T15:55:06+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -195,7 +195,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_3",
-                            "measurement time": "2025-05-12T15:55:18+00:00",
+                            "measurement time": "2025-03-11T15:55:18+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -245,7 +245,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_4",
-                            "measurement time": "2025-05-12T15:55:30+00:00",
+                            "measurement time": "2025-03-11T15:55:30+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -295,7 +295,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_5",
-                            "measurement time": "2025-05-12T15:55:42+00:00",
+                            "measurement time": "2025-03-11T15:55:42+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -345,7 +345,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_6",
-                            "measurement time": "2025-05-12T15:56:00+00:00",
+                            "measurement time": "2025-03-11T15:56:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -395,7 +395,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_7",
-                            "measurement time": "2025-05-12T15:56:12+00:00",
+                            "measurement time": "2025-03-11T15:56:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -445,7 +445,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_8",
-                            "measurement time": "2025-05-12T15:56:24+00:00",
+                            "measurement time": "2025-03-11T15:56:24+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -495,7 +495,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_9",
-                            "measurement time": "2025-05-12T15:56:36+00:00",
+                            "measurement time": "2025-03-11T15:56:36+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -545,7 +545,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_10",
-                            "measurement time": "2025-05-12T15:56:48+00:00",
+                            "measurement time": "2025-03-11T15:56:48+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -595,7 +595,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_11",
-                            "measurement time": "2025-05-12T15:57:00+00:00",
+                            "measurement time": "2025-03-11T15:57:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -645,7 +645,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_12",
-                            "measurement time": "2025-05-12T15:57:06+00:00",
+                            "measurement time": "2025-03-11T15:57:06+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -695,7 +695,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_13",
-                            "measurement time": "2025-05-12T15:57:24+00:00",
+                            "measurement time": "2025-03-11T15:57:24+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -745,7 +745,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_14",
-                            "measurement time": "2025-05-12T15:57:42+00:00",
+                            "measurement time": "2025-03-11T15:57:42+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -795,7 +795,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_15",
-                            "measurement time": "2025-05-12T15:57:48+00:00",
+                            "measurement time": "2025-03-11T15:57:48+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -845,7 +845,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_16",
-                            "measurement time": "2025-05-12T15:58:00+00:00",
+                            "measurement time": "2025-03-11T15:58:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -895,7 +895,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_17",
-                            "measurement time": "2025-05-12T15:58:12+00:00",
+                            "measurement time": "2025-03-11T15:58:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -945,7 +945,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_18",
-                            "measurement time": "2025-05-12T15:58:18+00:00",
+                            "measurement time": "2025-03-11T15:58:18+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -995,7 +995,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_19",
-                            "measurement time": "2025-05-12T15:58:30+00:00",
+                            "measurement time": "2025-03-11T15:58:30+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1045,7 +1045,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_20",
-                            "measurement time": "2025-05-12T15:58:42+00:00",
+                            "measurement time": "2025-03-11T15:58:42+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1095,7 +1095,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_21",
-                            "measurement time": "2025-05-12T15:59:00+00:00",
+                            "measurement time": "2025-03-11T15:59:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1145,7 +1145,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_22",
-                            "measurement time": "2025-05-12T15:59:12+00:00",
+                            "measurement time": "2025-03-11T15:59:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1195,7 +1195,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_23",
-                            "measurement time": "2025-05-12T15:59:24+00:00",
+                            "measurement time": "2025-03-11T15:59:24+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1245,7 +1245,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_24",
-                            "measurement time": "2025-05-12T15:59:36+00:00",
+                            "measurement time": "2025-03-11T15:59:36+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1295,7 +1295,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_25",
-                            "measurement time": "2025-05-12T15:59:48+00:00",
+                            "measurement time": "2025-03-11T15:59:48+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1345,7 +1345,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_26",
-                            "measurement time": "2025-05-12T16:00:00+00:00",
+                            "measurement time": "2025-03-11T16:00:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1395,7 +1395,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_27",
-                            "measurement time": "2025-05-12T16:00:12+00:00",
+                            "measurement time": "2025-03-11T16:00:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1445,7 +1445,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_28",
-                            "measurement time": "2025-05-12T16:00:24+00:00",
+                            "measurement time": "2025-03-11T16:00:24+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1495,7 +1495,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_29",
-                            "measurement time": "2025-05-12T16:00:42+00:00",
+                            "measurement time": "2025-03-11T16:00:42+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1545,7 +1545,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_30",
-                            "measurement time": "2025-05-12T16:00:54+00:00",
+                            "measurement time": "2025-03-11T16:00:54+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1595,7 +1595,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_31",
-                            "measurement time": "2025-05-12T16:01:06+00:00",
+                            "measurement time": "2025-03-11T16:01:06+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1645,7 +1645,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_32",
-                            "measurement time": "2025-05-12T16:01:12+00:00",
+                            "measurement time": "2025-03-11T16:01:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1695,7 +1695,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_33",
-                            "measurement time": "2025-05-12T16:01:24+00:00",
+                            "measurement time": "2025-03-11T16:01:24+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1745,7 +1745,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_34",
-                            "measurement time": "2025-05-12T16:01:36+00:00",
+                            "measurement time": "2025-03-11T16:01:36+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1795,7 +1795,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_35",
-                            "measurement time": "2025-05-12T16:01:48+00:00",
+                            "measurement time": "2025-03-11T16:01:48+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1845,7 +1845,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_36",
-                            "measurement time": "2025-05-12T16:01:54+00:00",
+                            "measurement time": "2025-03-11T16:01:54+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1895,7 +1895,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_37",
-                            "measurement time": "2025-05-12T16:02:12+00:00",
+                            "measurement time": "2025-03-11T16:02:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1945,7 +1945,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_38",
-                            "measurement time": "2025-05-12T16:02:24+00:00",
+                            "measurement time": "2025-03-11T16:02:24+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -1995,7 +1995,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_39",
-                            "measurement time": "2025-05-12T16:02:30+00:00",
+                            "measurement time": "2025-03-11T16:02:30+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2045,7 +2045,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_40",
-                            "measurement time": "2025-05-12T16:02:42+00:00",
+                            "measurement time": "2025-03-11T16:02:42+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2095,7 +2095,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_41",
-                            "measurement time": "2025-05-12T16:03:00+00:00",
+                            "measurement time": "2025-03-11T16:03:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2145,7 +2145,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_42",
-                            "measurement time": "2025-05-12T16:03:12+00:00",
+                            "measurement time": "2025-03-11T16:03:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2195,7 +2195,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_43",
-                            "measurement time": "2025-05-12T16:03:18+00:00",
+                            "measurement time": "2025-03-11T16:03:18+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2245,7 +2245,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_44",
-                            "measurement time": "2025-05-12T16:03:30+00:00",
+                            "measurement time": "2025-03-11T16:03:30+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2295,7 +2295,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_45",
-                            "measurement time": "2025-05-12T16:03:48+00:00",
+                            "measurement time": "2025-03-11T16:03:48+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2345,7 +2345,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_46",
-                            "measurement time": "2025-05-12T16:04:00+00:00",
+                            "measurement time": "2025-03-11T16:04:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2395,7 +2395,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_47",
-                            "measurement time": "2025-05-12T16:04:18+00:00",
+                            "measurement time": "2025-03-11T16:04:18+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2445,7 +2445,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_48",
-                            "measurement time": "2025-05-12T16:07:36+00:00",
+                            "measurement time": "2025-03-11T16:07:36+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2495,7 +2495,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_49",
-                            "measurement time": "2025-05-12T16:07:48+00:00",
+                            "measurement time": "2025-03-11T16:07:48+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2545,7 +2545,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_50",
-                            "measurement time": "2025-05-12T16:08:00+00:00",
+                            "measurement time": "2025-03-11T16:08:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2595,7 +2595,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_51",
-                            "measurement time": "2025-05-12T16:08:12+00:00",
+                            "measurement time": "2025-03-11T16:08:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2645,7 +2645,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_52",
-                            "measurement time": "2025-05-12T16:08:24+00:00",
+                            "measurement time": "2025-03-11T16:08:24+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2695,7 +2695,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_53",
-                            "measurement time": "2025-05-12T16:08:36+00:00",
+                            "measurement time": "2025-03-11T16:08:36+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2745,7 +2745,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_54",
-                            "measurement time": "2025-05-12T16:08:48+00:00",
+                            "measurement time": "2025-03-11T16:08:48+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2795,7 +2795,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_55",
-                            "measurement time": "2025-05-12T16:09:00+00:00",
+                            "measurement time": "2025-03-11T16:09:00+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2845,7 +2845,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_56",
-                            "measurement time": "2025-05-12T16:09:12+00:00",
+                            "measurement time": "2025-03-11T16:09:12+00:00",
                             "aspiration volume": {
                                 "value": 0.0,
                                 "unit": "μL"
@@ -2887,7 +2887,7 @@
                                 "destination well location identifier": "D4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_57",
-                            "measurement time": "2025-05-12T14:58:00+00:00",
+                            "measurement time": "2025-03-11T14:58:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2929,7 +2929,7 @@
                                 "destination well location identifier": "E4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_58",
-                            "measurement time": "2025-05-12T14:58:36+00:00",
+                            "measurement time": "2025-03-11T14:58:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2971,7 +2971,7 @@
                                 "destination well location identifier": "F4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_59",
-                            "measurement time": "2025-05-12T14:58:54+00:00",
+                            "measurement time": "2025-03-11T14:58:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3013,7 +3013,7 @@
                                 "destination well location identifier": "G4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_60",
-                            "measurement time": "2025-05-12T14:59:12+00:00",
+                            "measurement time": "2025-03-11T14:59:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3055,7 +3055,7 @@
                                 "destination well location identifier": "H4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_61",
-                            "measurement time": "2025-05-12T14:59:30+00:00",
+                            "measurement time": "2025-03-11T14:59:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3097,7 +3097,7 @@
                                 "destination well location identifier": "D5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_62",
-                            "measurement time": "2025-05-12T15:03:12+00:00",
+                            "measurement time": "2025-03-11T15:03:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3139,7 +3139,7 @@
                                 "destination well location identifier": "E5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_63",
-                            "measurement time": "2025-05-12T15:03:36+00:00",
+                            "measurement time": "2025-03-11T15:03:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3181,7 +3181,7 @@
                                 "destination well location identifier": "F5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_64",
-                            "measurement time": "2025-05-12T15:03:54+00:00",
+                            "measurement time": "2025-03-11T15:03:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3223,7 +3223,7 @@
                                 "destination well location identifier": "G5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_65",
-                            "measurement time": "2025-05-12T15:04:18+00:00",
+                            "measurement time": "2025-03-11T15:04:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3265,7 +3265,7 @@
                                 "destination well location identifier": "H5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_66",
-                            "measurement time": "2025-05-12T15:04:30+00:00",
+                            "measurement time": "2025-03-11T15:04:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3307,7 +3307,7 @@
                                 "destination well location identifier": "I5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_67",
-                            "measurement time": "2025-05-12T15:04:54+00:00",
+                            "measurement time": "2025-03-11T15:04:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3349,7 +3349,7 @@
                                 "destination well location identifier": "J5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_68",
-                            "measurement time": "2025-05-12T15:05:18+00:00",
+                            "measurement time": "2025-03-11T15:05:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3391,7 +3391,7 @@
                                 "destination well location identifier": "K5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_69",
-                            "measurement time": "2025-05-12T15:05:42+00:00",
+                            "measurement time": "2025-03-11T15:05:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3433,7 +3433,7 @@
                                 "destination well location identifier": "L5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_70",
-                            "measurement time": "2025-05-12T15:06:00+00:00",
+                            "measurement time": "2025-03-11T15:06:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3475,7 +3475,7 @@
                                 "destination well location identifier": "D6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_71",
-                            "measurement time": "2025-05-12T15:09:30+00:00",
+                            "measurement time": "2025-03-11T15:09:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3517,7 +3517,7 @@
                                 "destination well location identifier": "E6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_72",
-                            "measurement time": "2025-05-12T15:10:12+00:00",
+                            "measurement time": "2025-03-11T15:10:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3559,7 +3559,7 @@
                                 "destination well location identifier": "F6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_73",
-                            "measurement time": "2025-05-12T15:10:24+00:00",
+                            "measurement time": "2025-03-11T15:10:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3601,7 +3601,7 @@
                                 "destination well location identifier": "G6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_74",
-                            "measurement time": "2025-05-12T15:10:54+00:00",
+                            "measurement time": "2025-03-11T15:10:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3643,7 +3643,7 @@
                                 "destination well location identifier": "H6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_75",
-                            "measurement time": "2025-05-12T15:11:12+00:00",
+                            "measurement time": "2025-03-11T15:11:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3685,7 +3685,7 @@
                                 "destination well location identifier": "I6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_76",
-                            "measurement time": "2025-05-12T15:11:36+00:00",
+                            "measurement time": "2025-03-11T15:11:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3727,7 +3727,7 @@
                                 "destination well location identifier": "J6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_77",
-                            "measurement time": "2025-05-12T15:12:00+00:00",
+                            "measurement time": "2025-03-11T15:12:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3769,7 +3769,7 @@
                                 "destination well location identifier": "K6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_78",
-                            "measurement time": "2025-05-12T15:12:24+00:00",
+                            "measurement time": "2025-03-11T15:12:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3811,7 +3811,7 @@
                                 "destination well location identifier": "L6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_79",
-                            "measurement time": "2025-05-12T15:12:42+00:00",
+                            "measurement time": "2025-03-11T15:12:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3853,7 +3853,7 @@
                                 "destination well location identifier": "D8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_80",
-                            "measurement time": "2025-05-12T15:16:12+00:00",
+                            "measurement time": "2025-03-11T15:16:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3895,7 +3895,7 @@
                                 "destination well location identifier": "E8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_81",
-                            "measurement time": "2025-05-12T15:16:48+00:00",
+                            "measurement time": "2025-03-11T15:16:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3937,7 +3937,7 @@
                                 "destination well location identifier": "F8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_82",
-                            "measurement time": "2025-05-12T15:17:06+00:00",
+                            "measurement time": "2025-03-11T15:17:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3979,7 +3979,7 @@
                                 "destination well location identifier": "G8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_83",
-                            "measurement time": "2025-05-12T15:17:30+00:00",
+                            "measurement time": "2025-03-11T15:17:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4021,7 +4021,7 @@
                                 "destination well location identifier": "H8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_84",
-                            "measurement time": "2025-05-12T15:17:54+00:00",
+                            "measurement time": "2025-03-11T15:17:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4063,7 +4063,7 @@
                                 "destination well location identifier": "I8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_85",
-                            "measurement time": "2025-05-12T15:18:12+00:00",
+                            "measurement time": "2025-03-11T15:18:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4105,7 +4105,7 @@
                                 "destination well location identifier": "J8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_86",
-                            "measurement time": "2025-05-12T15:18:42+00:00",
+                            "measurement time": "2025-03-11T15:18:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4147,7 +4147,7 @@
                                 "destination well location identifier": "K8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_87",
-                            "measurement time": "2025-05-12T15:19:00+00:00",
+                            "measurement time": "2025-03-11T15:19:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4189,7 +4189,7 @@
                                 "destination well location identifier": "L8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_88",
-                            "measurement time": "2025-05-12T15:19:24+00:00",
+                            "measurement time": "2025-03-11T15:19:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4231,7 +4231,7 @@
                                 "destination well location identifier": "D9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_89",
-                            "measurement time": "2025-05-12T15:23:00+00:00",
+                            "measurement time": "2025-03-11T15:23:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4273,7 +4273,7 @@
                                 "destination well location identifier": "E9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_90",
-                            "measurement time": "2025-05-12T15:23:30+00:00",
+                            "measurement time": "2025-03-11T15:23:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4315,7 +4315,7 @@
                                 "destination well location identifier": "F9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_91",
-                            "measurement time": "2025-05-12T15:23:48+00:00",
+                            "measurement time": "2025-03-11T15:23:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4357,7 +4357,7 @@
                                 "destination well location identifier": "G9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_92",
-                            "measurement time": "2025-05-12T15:24:12+00:00",
+                            "measurement time": "2025-03-11T15:24:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4399,7 +4399,7 @@
                                 "destination well location identifier": "H9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_93",
-                            "measurement time": "2025-05-12T15:24:30+00:00",
+                            "measurement time": "2025-03-11T15:24:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4441,7 +4441,7 @@
                                 "destination well location identifier": "I9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_94",
-                            "measurement time": "2025-05-12T15:24:48+00:00",
+                            "measurement time": "2025-03-11T15:24:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4483,7 +4483,7 @@
                                 "destination well location identifier": "J9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_95",
-                            "measurement time": "2025-05-12T15:25:06+00:00",
+                            "measurement time": "2025-03-11T15:25:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4525,7 +4525,7 @@
                                 "destination well location identifier": "K9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_96",
-                            "measurement time": "2025-05-12T15:25:30+00:00",
+                            "measurement time": "2025-03-11T15:25:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4567,7 +4567,7 @@
                                 "destination well location identifier": "L9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_97",
-                            "measurement time": "2025-05-12T15:25:54+00:00",
+                            "measurement time": "2025-03-11T15:25:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4609,7 +4609,7 @@
                                 "destination well location identifier": "D10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_98",
-                            "measurement time": "2025-05-12T15:29:30+00:00",
+                            "measurement time": "2025-03-11T15:29:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4651,7 +4651,7 @@
                                 "destination well location identifier": "E10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_99",
-                            "measurement time": "2025-05-12T15:30:12+00:00",
+                            "measurement time": "2025-03-11T15:30:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4693,7 +4693,7 @@
                                 "destination well location identifier": "F10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_100",
-                            "measurement time": "2025-05-12T15:30:30+00:00",
+                            "measurement time": "2025-03-11T15:30:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4735,7 +4735,7 @@
                                 "destination well location identifier": "G10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_101",
-                            "measurement time": "2025-05-12T15:31:00+00:00",
+                            "measurement time": "2025-03-11T15:31:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4777,7 +4777,7 @@
                                 "destination well location identifier": "H10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_102",
-                            "measurement time": "2025-05-12T15:31:18+00:00",
+                            "measurement time": "2025-03-11T15:31:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4819,7 +4819,7 @@
                                 "destination well location identifier": "I10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_103",
-                            "measurement time": "2025-05-12T15:31:36+00:00",
+                            "measurement time": "2025-03-11T15:31:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4861,7 +4861,7 @@
                                 "destination well location identifier": "J10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_104",
-                            "measurement time": "2025-05-12T15:32:00+00:00",
+                            "measurement time": "2025-03-11T15:32:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4903,7 +4903,7 @@
                                 "destination well location identifier": "K10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_105",
-                            "measurement time": "2025-05-12T15:32:18+00:00",
+                            "measurement time": "2025-03-11T15:32:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4945,7 +4945,7 @@
                                 "destination well location identifier": "L10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_106",
-                            "measurement time": "2025-05-12T15:32:42+00:00",
+                            "measurement time": "2025-03-11T15:32:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4987,7 +4987,7 @@
                                 "destination well location identifier": "D11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_107",
-                            "measurement time": "2025-05-12T15:36:24+00:00",
+                            "measurement time": "2025-03-11T15:36:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5029,7 +5029,7 @@
                                 "destination well location identifier": "E11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_108",
-                            "measurement time": "2025-05-12T15:36:54+00:00",
+                            "measurement time": "2025-03-11T15:36:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5071,7 +5071,7 @@
                                 "destination well location identifier": "F11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_109",
-                            "measurement time": "2025-05-12T15:37:12+00:00",
+                            "measurement time": "2025-03-11T15:37:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5113,7 +5113,7 @@
                                 "destination well location identifier": "G11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_110",
-                            "measurement time": "2025-05-12T15:37:30+00:00",
+                            "measurement time": "2025-03-11T15:37:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5155,7 +5155,7 @@
                                 "destination well location identifier": "H11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_111",
-                            "measurement time": "2025-05-12T15:37:54+00:00",
+                            "measurement time": "2025-03-11T15:37:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5197,7 +5197,7 @@
                                 "destination well location identifier": "I11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_112",
-                            "measurement time": "2025-05-12T15:38:12+00:00",
+                            "measurement time": "2025-03-11T15:38:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5239,7 +5239,7 @@
                                 "destination well location identifier": "J11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_113",
-                            "measurement time": "2025-05-12T15:38:36+00:00",
+                            "measurement time": "2025-03-11T15:38:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5281,7 +5281,7 @@
                                 "destination well location identifier": "K11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_114",
-                            "measurement time": "2025-05-12T15:39:00+00:00",
+                            "measurement time": "2025-03-11T15:39:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5323,7 +5323,7 @@
                                 "destination well location identifier": "L11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_115",
-                            "measurement time": "2025-05-12T15:39:18+00:00",
+                            "measurement time": "2025-03-11T15:39:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5365,7 +5365,7 @@
                                 "destination well location identifier": "D12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_116",
-                            "measurement time": "2025-05-12T15:42:54+00:00",
+                            "measurement time": "2025-03-11T15:42:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5407,7 +5407,7 @@
                                 "destination well location identifier": "E12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_117",
-                            "measurement time": "2025-05-12T15:43:18+00:00",
+                            "measurement time": "2025-03-11T15:43:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5449,7 +5449,7 @@
                                 "destination well location identifier": "F12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_118",
-                            "measurement time": "2025-05-12T15:43:36+00:00",
+                            "measurement time": "2025-03-11T15:43:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5491,7 +5491,7 @@
                                 "destination well location identifier": "G12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_119",
-                            "measurement time": "2025-05-12T15:43:54+00:00",
+                            "measurement time": "2025-03-11T15:43:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5533,7 +5533,7 @@
                                 "destination well location identifier": "H12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_120",
-                            "measurement time": "2025-05-12T15:44:18+00:00",
+                            "measurement time": "2025-03-11T15:44:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5575,7 +5575,7 @@
                                 "destination well location identifier": "I12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_121",
-                            "measurement time": "2025-05-12T15:44:42+00:00",
+                            "measurement time": "2025-03-11T15:44:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5617,7 +5617,7 @@
                                 "destination well location identifier": "J12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_122",
-                            "measurement time": "2025-05-12T15:45:06+00:00",
+                            "measurement time": "2025-03-11T15:45:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5659,7 +5659,7 @@
                                 "destination well location identifier": "K12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_123",
-                            "measurement time": "2025-05-12T15:45:24+00:00",
+                            "measurement time": "2025-03-11T15:45:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5701,7 +5701,7 @@
                                 "destination well location identifier": "L12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_124",
-                            "measurement time": "2025-05-12T15:45:48+00:00",
+                            "measurement time": "2025-03-11T15:45:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5743,7 +5743,7 @@
                                 "destination well location identifier": "L13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_125",
-                            "measurement time": "2025-05-12T15:46:00+00:00",
+                            "measurement time": "2025-03-11T15:46:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5785,7 +5785,7 @@
                                 "destination well location identifier": "K13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_126",
-                            "measurement time": "2025-05-12T15:46:18+00:00",
+                            "measurement time": "2025-03-11T15:46:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5827,7 +5827,7 @@
                                 "destination well location identifier": "J13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_127",
-                            "measurement time": "2025-05-12T15:46:42+00:00",
+                            "measurement time": "2025-03-11T15:46:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5869,7 +5869,7 @@
                                 "destination well location identifier": "I13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_128",
-                            "measurement time": "2025-05-12T15:47:06+00:00",
+                            "measurement time": "2025-03-11T15:47:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5911,7 +5911,7 @@
                                 "destination well location identifier": "H13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_129",
-                            "measurement time": "2025-05-12T15:47:24+00:00",
+                            "measurement time": "2025-03-11T15:47:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5953,7 +5953,7 @@
                                 "destination well location identifier": "G13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_130",
-                            "measurement time": "2025-05-12T15:47:48+00:00",
+                            "measurement time": "2025-03-11T15:47:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5995,7 +5995,7 @@
                                 "destination well location identifier": "F13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_131",
-                            "measurement time": "2025-05-12T15:48:12+00:00",
+                            "measurement time": "2025-03-11T15:48:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -6037,7 +6037,7 @@
                                 "destination well location identifier": "E13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_132",
-                            "measurement time": "2025-05-12T15:48:30+00:00",
+                            "measurement time": "2025-03-11T15:48:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -6079,7 +6079,7 @@
                                 "destination well location identifier": "D13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_133",
-                            "measurement time": "2025-05-12T15:48:54+00:00",
+                            "measurement time": "2025-03-11T15:48:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -6121,7 +6121,7 @@
                                 "destination well location identifier": "D15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_134",
-                            "measurement time": "2025-05-12T15:52:42+00:00",
+                            "measurement time": "2025-03-11T15:52:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -6163,7 +6163,7 @@
                                 "destination well location identifier": "E15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_135",
-                            "measurement time": "2025-05-12T15:53:00+00:00",
+                            "measurement time": "2025-03-11T15:53:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -6205,7 +6205,7 @@
                                 "destination well location identifier": "F15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_136",
-                            "measurement time": "2025-05-12T15:53:24+00:00",
+                            "measurement time": "2025-03-11T15:53:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -6247,7 +6247,7 @@
                                 "destination well location identifier": "G15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_137",
-                            "measurement time": "2025-05-12T15:53:42+00:00",
+                            "measurement time": "2025-03-11T15:53:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -6289,7 +6289,7 @@
                                 "destination well location identifier": "H15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_138",
-                            "measurement time": "2025-05-12T15:54:12+00:00",
+                            "measurement time": "2025-03-11T15:54:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -6331,7 +6331,7 @@
                                 "destination well location identifier": "I15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_139",
-                            "measurement time": "2025-05-12T15:54:30+00:00",
+                            "measurement time": "2025-03-11T15:54:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"


### PR DESCRIPTION
One example file has the per-measurement time missing a date (it provides time only).

In this case, the default behavior of the dateutil library is to use today's date, which is incorrect.

Instead, fill the date with the file header's date, is possible.

If the measurement time is missing a date, and the header has no date, throw an error.