### PR TITLE
fix: Agilent OpenLab CDS - use bytes to read zip file instead of file name

### DIFF
--- a/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_decoder.py
+++ b/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_decoder.py
@@ -9,6 +9,8 @@ import zipfile
 import rainbow.agilent.chemstation as rb  # type: ignore
 import xmltodict
 
+from allotropy.types import IOType
+
 
 def merge_peak_with_signal_name(
     peak_data: list[dict[str, Any]],
@@ -273,7 +275,7 @@ def _get_matching_filenames(zip_ref: zipfile.ZipFile, pattern: str) -> list[str]
     ]
 
 
-def decode_data(input_bytes: IO[bytes]) -> dict[str, Any]:
+def decode_data(input_bytes: IOType) -> dict[str, Any]:
     """
     decoded the files in input folder path and returns a structured data
     :param input_path: input folder path

--- a/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_decoder.py
+++ b/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_decoder.py
@@ -273,7 +273,7 @@ def _get_matching_filenames(zip_ref: zipfile.ZipFile, pattern: str) -> list[str]
     ]
 
 
-def decode_data(input_path: str) -> dict[str, Any]:
+def decode_data(input_bytes: IO[bytes]) -> dict[str, Any]:
     """
     decoded the files in input folder path and returns a structured data
     :param input_path: input folder path
@@ -284,7 +284,7 @@ def decode_data(input_path: str) -> dict[str, Any]:
     total_injection_chromatogram_details: list[dict[str, Any]] = []
     total_peak_details: list[dict[str, Any]] = []
 
-    with zipfile.ZipFile(input_path, "r") as zip_ref:
+    with zipfile.ZipFile(input_bytes) as zip_ref:
         acaml_path = next(iter(_get_matching_filenames(zip_ref, ".*acaml")))
         with zip_ref.open(acaml_path) as acaml_file_data:
             acaml_file_content = acaml_file_data.read().decode("utf-8-sig")

--- a/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_decoder.py
+++ b/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_decoder.py
@@ -9,8 +9,6 @@ import zipfile
 import rainbow.agilent.chemstation as rb  # type: ignore
 import xmltodict
 
-from allotropy.types import IOType
-
 
 def merge_peak_with_signal_name(
     peak_data: list[dict[str, Any]],
@@ -275,7 +273,7 @@ def _get_matching_filenames(zip_ref: zipfile.ZipFile, pattern: str) -> list[str]
     ]
 
 
-def decode_data(input_bytes: IOType) -> dict[str, Any]:
+def decode_data(input_bytes: IO[bytes]) -> dict[str, Any]:
     """
     decoded the files in input folder path and returns a structured data
     :param input_path: input folder path

--- a/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_parser.py
+++ b/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_parser.py
@@ -26,7 +26,7 @@ class AgilentOpenLabCDSParser(VendorParser[Data, Model]):
     SCHEMA_MAPPER = Mapper
 
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
-        structured_data = decode_data(named_file_contents.contents)
+        structured_data = decode_data(named_file_contents.get_bytes_stream())
         return Data(
             metadata=create_metadata(structured_data, named_file_contents),
             measurement_groups=[create_measurement_groups(structured_data)],

--- a/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_parser.py
+++ b/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_parser.py
@@ -26,7 +26,7 @@ class AgilentOpenLabCDSParser(VendorParser[Data, Model]):
     SCHEMA_MAPPER = Mapper
 
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
-        structured_data = decode_data(named_file_contents.original_file_path)
+        structured_data = decode_data(named_file_contents.contents)
         return Data(
             metadata=create_metadata(structured_data, named_file_contents),
             measurement_groups=[create_measurement_groups(structured_data)],


### PR DESCRIPTION
Allotropy parsers must read from bytes, not from local files, as the interface allows passing in bytes.