### PR TITLE
chore: Skip uri-reference schema format check

### DIFF
--- a/src/allotropy/testing/utils.py
+++ b/src/allotropy/testing/utils.py
@@ -45,6 +45,7 @@ NON_UNIQUE_IDENTIFIERS = {
     "batch identifier",
     "data source identifier",
     "device identifier",
+    "device method identifier",
     "experimental data identifier",
     "flow cell identifier",
     "group identifier",


### PR DESCRIPTION
If the python environment has certain validators installed, jsonschema will add the uri-reference format validator, which the ASM schemas currently fail against.

So, remove it from our validation check.