### PR TITLE
fix: Map missing fields in Chromeleon parser for adapter migration

### DIFF
--- a/src/allotropy/allotrope/schema_mappers/adm/liquid_chromatography/benchling/_2023/_09/liquid_chromatography.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/liquid_chromatography/benchling/_2023/_09/liquid_chromatography.py
@@ -244,6 +244,8 @@ class Measurement:
 @dataclass(frozen=True)
 class MeasurementGroup:
     measurements: list[Measurement]
+    analyst: str | None = None
+    submitter: str | None = None
     fractions: list[Fraction] | None = None
     logs: list[Log] | None = None
     measurement_aggregate_custom_info: dict[str, Any] | None = None
@@ -317,7 +319,8 @@ class Mapper(SchemaMapper[Data, Model]):
         self, group: MeasurementGroup, metadata: Metadata
     ) -> LiquidChromatographyDocumentItem:
         return LiquidChromatographyDocumentItem(
-            analyst=metadata.analyst,
+            analyst=group.analyst or metadata.analyst,
+            submitter=group.submitter,
             measurement_aggregate_document=add_custom_information_document(
                 MeasurementAggregateDocument(
                     measurement_document=[

--- a/src/allotropy/parsers/benchling_chromeleon/benchling_chromeleon_reader.py
+++ b/src/allotropy/parsers/benchling_chromeleon/benchling_chromeleon_reader.py
@@ -14,7 +14,9 @@ class BenchlingChromeleonReader:
     def __init__(self, named_file_contents: NamedFileContents) -> None:
         contents: dict[str, Any] = json.load(named_file_contents.contents)
         self.sequence: dict[str, Any] = contents.get("sequence", {})
-        self.device_information: dict[str, Any] = contents.get("device information", {})
+        self.device_information: dict[str, Any] = (
+            contents.get("device information") or {}
+        )
         self.injections: list[dict[str, Any]] = assert_not_none(
             contents.get("injections"), "injections"
         )

--- a/src/allotropy/parsers/benchling_chromeleon/benchling_chromeleon_structure.py
+++ b/src/allotropy/parsers/benchling_chromeleon/benchling_chromeleon_structure.py
@@ -28,8 +28,10 @@ from allotropy.parsers.utils.values import try_float, try_float_or_none
 
 
 def _create_device_documents(
-    device_information: dict[str, Any]
+    device_information: dict[str, Any] | None,
 ) -> list[DeviceDocument] | None:
+    if not device_information:
+        return None
     return [
         DeviceDocument(
             device_type="pump",
@@ -51,12 +53,15 @@ def create_metadata(
     first_injection: dict[str, Any],
     sequence: dict[str, Any],
     file_path: str,
-    device_information: dict[str, Any],
+    device_information: dict[str, Any] | None,
 ) -> Metadata:
+    asset_management_identifier = (
+        (device_information.get("sampler model number") if device_information else None)
+        or first_injection.get("precondition system instrument name")
+        or NOT_APPLICABLE
+    )
     return Metadata(
-        asset_management_identifier=first_injection.get(
-            "precondition system instrument name", NOT_APPLICABLE
-        ),
+        asset_management_identifier=asset_management_identifier,
         software_name=constants.SOFTWARE_NAME,
         file_name=Path(file_path).name,
         unc_path=file_path,
@@ -223,6 +228,7 @@ def _create_measurements(injection: dict[str, Any]) -> list[Measurement] | None:
             measurement_identifier=random_uuid_str(),
             description=injection.get("description"),
             sample_identifier=injection["sample identifier"],
+            written_name=injection.get("injection name"),
             location_identifier=injection.get("location identifier"),
             well_location_identifier=injection.get("custom variables", {}).get("Well"),
             observation=injection.get("custom variables", {}).get("Observation"),
@@ -239,7 +245,7 @@ def _create_measurements(injection: dict[str, Any]) -> list[Measurement] | None:
             },
             device_control_docs=[
                 DeviceControlDoc(
-                    device_type=constants.DEVICE_TYPE,
+                    device_type=signal.get("signal name", constants.DEVICE_TYPE),
                     detection_type=signal.get("detection type"),
                     detector_offset_setting=val
                     if (val := signal.get("detector offset setting")) != "unknown"
@@ -271,6 +277,11 @@ def _create_measurements(injection: dict[str, Any]) -> list[Measurement] | None:
                 "creation user name": injection.get("creation user name"),
                 "injection program": injection.get("injection program"),
                 "injection method": injection.get("injection method"),
+                **{
+                    k: v
+                    for k, v in injection.get("custom variables", {}).items()
+                    if v is not None
+                },
             },
             chromatography_serial_num=NOT_APPLICABLE,
             chromatogram_data_cube=_get_chromatogram(signal) if signal else None,
@@ -284,7 +295,11 @@ def create_measurement_groups(
     injections: list[dict[str, Any]]
 ) -> list[MeasurementGroup]:
     return [
-        MeasurementGroup(measurements=measurements)
-        for sample_injections in injections
-        if (measurements := _create_measurements(sample_injections)) is not None
+        MeasurementGroup(
+            measurements=measurements,
+            analyst=injection.get("last update user name"),
+            submitter=injection.get("creation user name"),
+        )
+        for injection in injections
+        if (measurements := _create_measurements(injection)) is not None
     ]

--- a/tests/parsers/benchling_chromeleon/benchling_chromeleon_structure_test.py
+++ b/tests/parsers/benchling_chromeleon/benchling_chromeleon_structure_test.py
@@ -117,7 +117,7 @@ def test_create_metadata(mock_data: dict[str, Any]) -> None:
     )
 
     assert isinstance(metadata, Metadata)
-    assert metadata.asset_management_identifier == "Instrument123"
+    assert metadata.asset_management_identifier == "WPS-3000RS"
     assert metadata.software_name == constants.SOFTWARE_NAME
     assert metadata.file_name == "test_file.json"
     assert metadata.unc_path == "/data/test_file.json"
@@ -173,7 +173,7 @@ def test_create_measurement_groups(mock_data: dict[str, Any]) -> None:
 
     device_control_doc = measurement.device_control_docs[0]
     assert device_control_doc is not None
-    assert device_control_doc.device_type == constants.DEVICE_TYPE
+    assert device_control_doc.device_type == "UV_VIS_1"
     assert device_control_doc.detection_type == "single channel"
     assert device_control_doc.electronic_absorbance_reference_bandwidth_setting == 1.0
     assert device_control_doc.electronic_absorbance_reference_wavelength_setting == 0.0

--- a/tests/parsers/benchling_chromeleon/testdata/input/chromeleon_example_multi_signal.json
+++ b/tests/parsers/benchling_chromeleon/testdata/input/chromeleon_example_multi_signal.json
@@ -1,0 +1,123 @@
+{
+  "device information": {
+    "pump model number": "VF-P10-A",
+    "uv model number": "VF-D40-A",
+    "sampler model number": "VF-A10-A"
+  },
+  "sequence": {
+    "sequence creation time": "2026-02-13T10:00:00+01:00",
+    "sequence directory": "ChromeleonLocal",
+    "sequence name": "Test_MultiSignal",
+    "sequence update operator": "operator1",
+    "sequence update time": "2026-02-14T15:00:00+01:00",
+    "custom formulas": []
+  },
+  "injections": [
+    {
+      "injection number": 1,
+      "injection name": "MQW",
+      "injection identifier": "99999999-8888-7777-6666-555555555555",
+      "injection time": "2026-02-14T21:52:50+01:00",
+      "injection position": "B:A1",
+      "injection status": "Finished",
+      "injection type": "Unknown",
+      "description": "",
+      "sample identifier": "",
+      "location identifier": "B:A1",
+      "last update user name": "Instrument Controller",
+      "creation user name": "PD01",
+      "detection type": "single channel",
+      "injection volume setting": 4.0,
+      "injection volume setting unit": "uL",
+      "custom variables": {
+        "ColumnValvePosition": 1.0
+      },
+      "signals": [
+        {
+          "signal name": "UV_VIS_1",
+          "detection type": "single channel",
+          "detector sampling rate setting": "unknown",
+          "detector offset setting": "unknown",
+          "bandwidth setting": 4.0,
+          "wavelength setting": 220.0,
+          "reference bandwidth setting": null,
+          "reference wavelength setting": null,
+          "chromatogram": {
+            "x": [
+              0.0,
+              0.5,
+              1.0,
+              1.5,
+              2.0
+            ],
+            "y": [
+              0.0,
+              0.5,
+              1.0,
+              0.5,
+              0.0
+            ]
+          },
+          "peaks": []
+        },
+        {
+          "signal name": "UV_VIS_2",
+          "detection type": "single channel",
+          "detector sampling rate setting": "unknown",
+          "detector offset setting": "unknown",
+          "bandwidth setting": 4.0,
+          "wavelength setting": 280.0,
+          "reference bandwidth setting": null,
+          "reference wavelength setting": null,
+          "chromatogram": {
+            "x": [
+              0.0,
+              0.5,
+              1.0,
+              1.5,
+              2.0
+            ],
+            "y": [
+              0.0,
+              0.3,
+              0.8,
+              0.3,
+              0.0
+            ]
+          },
+          "peaks": [
+            {
+              "identifier": "1",
+              "name": "Peak1",
+              "start time": 0.4,
+              "end time": 1.6,
+              "retention time": 1.0,
+              "area": 8000.0,
+              "height": 800.0,
+              "relative peak area": 100.0,
+              "relative peak height": 100.0,
+              "peak width at half height": 0.6,
+              "peak width at 5 % of height": null,
+              "peak width at 10 % of height": null,
+              "peak width at baseline": null,
+              "amount": null,
+              "relative retention time": null,
+              "capacity factor": null,
+              "chromatographic peak resolution": null,
+              "number of theoretical plates by peak width at half height": null,
+              "asymmetry factor measured at 5 % height": null,
+              "start value baseline": null,
+              "stop value baseline": null,
+              "peak right width at 10 % of height": null,
+              "peak left width at 10 % of height": null,
+              "group area": null,
+              "rel ce area total": null,
+              "chromatographic peak resolution (USP)": null,
+              "asymmetry aia": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parsers/benchling_chromeleon/testdata/input/chromeleon_example_null_device_info.json
+++ b/tests/parsers/benchling_chromeleon/testdata/input/chromeleon_example_null_device_info.json
@@ -1,0 +1,177 @@
+{
+  "device information": null,
+  "sequence": {
+    "sequence creation time": "2024-09-23T08:00:00-07:00",
+    "sequence directory": "ChromeleonLocal",
+    "sequence name": "Test_Null_DeviceInfo",
+    "sequence update operator": "testuser",
+    "sequence update time": "2024-09-23T09:00:00-07:00",
+    "custom formulas": []
+  },
+  "injections": [
+    {
+      "injection number": 1,
+      "injection name": "Blank Conditioning",
+      "injection identifier": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "injection time": "2024-09-23T08:05:00-07:00",
+      "injection position": "P1:A1",
+      "injection status": "Finished",
+      "injection type": "Unknown",
+      "description": "test description",
+      "sample identifier": "SAMPLE-001",
+      "location identifier": "P1:A1",
+      "last update user name": "Instrument Controller",
+      "creation user name": "testuser",
+      "detection type": "single channel",
+      "injection volume setting": 5.0,
+      "injection volume setting unit": "uL",
+      "custom variables": {
+        "Analysis_Type": "Laboratory Reagent Blank (LRB)",
+        "Fortified": "LFB Set",
+        "Duplicate": null
+      },
+      "signals": [
+        {
+          "signal name": "FLD1_Signal_A",
+          "detection type": "single channel",
+          "detector sampling rate setting": "unknown",
+          "detector offset setting": "unknown",
+          "bandwidth setting": null,
+          "wavelength setting": 280.0,
+          "reference bandwidth setting": null,
+          "reference wavelength setting": null,
+          "chromatogram": {
+            "x": [
+              0.0,
+              0.1,
+              0.2,
+              0.3,
+              0.4
+            ],
+            "y": [
+              0.0,
+              1.5,
+              3.2,
+              2.1,
+              0.5
+            ]
+          },
+          "peaks": [
+            {
+              "identifier": "1",
+              "name": "Peak1",
+              "start time": 0.05,
+              "end time": 0.35,
+              "retention time": 0.2,
+              "area": 5000.0,
+              "height": 3200.0,
+              "relative peak area": 100.0,
+              "relative peak height": 100.0,
+              "peak width at half height": 0.1,
+              "peak width at 5 % of height": null,
+              "peak width at 10 % of height": null,
+              "peak width at baseline": null,
+              "amount": null,
+              "relative retention time": null,
+              "capacity factor": null,
+              "chromatographic peak resolution": null,
+              "number of theoretical plates by peak width at half height": null,
+              "asymmetry factor measured at 5 % height": null,
+              "start value baseline": null,
+              "stop value baseline": null,
+              "peak right width at 10 % of height": null,
+              "peak left width at 10 % of height": null,
+              "group area": null,
+              "rel ce area total": null,
+              "chromatographic peak resolution (USP)": null,
+              "asymmetry aia": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "injection number": 2,
+      "injection name": "Standard 1",
+      "injection identifier": "11111111-2222-3333-4444-555555555555",
+      "injection time": "2024-09-23T08:15:00-07:00",
+      "injection position": "P1:A2",
+      "injection status": "Finished",
+      "injection type": "Unknown",
+      "description": "",
+      "sample identifier": "STD-001",
+      "location identifier": "P1:A2",
+      "last update user name": "labuser",
+      "creation user name": "admin",
+      "detection type": "single channel",
+      "injection volume setting": 10.0,
+      "injection volume setting unit": "uL",
+      "custom variables": {
+        "Analysis_Type": "Calibration Standard",
+        "Fortified": null,
+        "Duplicate": null
+      },
+      "signals": [
+        {
+          "signal name": "CD_1",
+          "detection type": "single channel",
+          "detector sampling rate setting": 2.5,
+          "detector offset setting": "unknown",
+          "bandwidth setting": 4.0,
+          "wavelength setting": 254.0,
+          "reference bandwidth setting": null,
+          "reference wavelength setting": 360.0,
+          "chromatogram": {
+            "x": [
+              0.0,
+              0.1,
+              0.2,
+              0.3,
+              0.4,
+              0.5
+            ],
+            "y": [
+              0.1,
+              2.0,
+              5.5,
+              4.0,
+              1.2,
+              0.2
+            ]
+          },
+          "peaks": [
+            {
+              "identifier": "1",
+              "name": "Analyte1",
+              "start time": 0.08,
+              "end time": 0.42,
+              "retention time": 0.2,
+              "area": 12000.0,
+              "height": 5500.0,
+              "relative peak area": 100.0,
+              "relative peak height": 100.0,
+              "peak width at half height": 0.15,
+              "peak width at 5 % of height": 0.25,
+              "peak width at 10 % of height": 0.22,
+              "peak width at baseline": 0.34,
+              "amount": 50.0,
+              "relative retention time": 1.0,
+              "capacity factor": 2.5,
+              "chromatographic peak resolution": 1.8,
+              "number of theoretical plates by peak width at half height": 500.0,
+              "asymmetry factor measured at 5 % height": 1.2,
+              "start value baseline": 0.01,
+              "stop value baseline": 0.02,
+              "peak right width at 10 % of height": 0.12,
+              "peak left width at 10 % of height": 0.1,
+              "group area": 15000.0,
+              "rel ce area total": 95.0,
+              "chromatographic peak resolution (USP)": 1.75,
+              "asymmetry aia": 1.1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parsers/benchling_chromeleon/testdata/output/chromeleon_example.json
+++ b/tests/parsers/benchling_chromeleon/testdata/output/chromeleon_example.json
@@ -1,6146 +1,6209 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/liquid-chromatography/BENCHLING/2023/09/liquid-chromatography.manifest",
-    "liquid chromatography aggregate document": {
-        "liquid chromatography document": [
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RA1"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_0",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_1",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_2",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_3",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "bee79522-5ead-406e-a656-66534b588357",
-                                "injection time": "2011-07-15T16:27:39+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 1,
-                                    "injection name": "Blank",
-                                    "injection position": "RA1",
-                                    "injection status": "Finished",
-                                    "injection type": "Blank",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RA2"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_4",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_5",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_6",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_7",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "b643326f-e8ea-44a0-9257-16a885f4baa3",
-                                "injection time": "2011-07-15T16:28:24+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 2,
-                                    "injection name": "SST Standard",
-                                    "injection position": "RA2",
-                                    "injection status": "Finished",
-                                    "injection type": "CheckStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RA3"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_8",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_9",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_10",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_11",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "a9df04e0-fa0b-4619-a598-6b68a6961c13",
-                                "injection time": "2011-07-15T16:29:09+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 3,
-                                    "injection name": "SST Standard",
-                                    "injection position": "RA3",
-                                    "injection status": "Finished",
-                                    "injection type": "CheckStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RA4"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_12",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_13",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_14",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_15",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "56c3c2e1-2ef5-4ef5-95aa-7d14cee8b6f5",
-                                "injection time": "2011-07-12T16:31:17+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 4,
-                                    "injection name": "SST Standard",
-                                    "injection position": "RA4",
-                                    "injection status": "Finished",
-                                    "injection type": "CheckStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RA5"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_16",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_17",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_18",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_19",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "514dca95-4e3c-4422-a75e-bfed635c308b",
-                                "injection time": "2011-07-12T16:32:03+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 5,
-                                    "injection name": "SST Standard",
-                                    "injection position": "RA5",
-                                    "injection status": "Finished",
-                                    "injection type": "CheckStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RA6"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_20",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_21",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_22",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_23",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "4c5b6a6d-6f57-4123-98f4-8217f8c48351",
-                                "injection time": "2011-07-12T16:32:49+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 6,
-                                    "injection name": "SST Standard",
-                                    "injection position": "RA6",
-                                    "injection status": "Finished",
-                                    "injection type": "CheckStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RA7"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_24",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_25",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_26",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_27",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "5a6636fe-24b0-4094-96ba-d96a62aa3355",
-                                "injection time": "2011-07-12T16:33:34+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 7,
-                                    "injection name": "Calibration Standard",
-                                    "injection position": "RA7",
-                                    "injection status": "Finished",
-                                    "injection type": "CalibrationStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RA8"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_28",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_29",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_30",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_31",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "4848ed9c-2128-45d8-b4f0-1d3d849aaa4e",
-                                "injection time": "2011-07-12T16:34:19+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 8,
-                                    "injection name": "Calibration Standard",
-                                    "injection position": "RA8",
-                                    "injection status": "Finished",
-                                    "injection type": "CalibrationStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RB1"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_32",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_33",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_34",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_35",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "b67cdd52-c9db-447a-9369-e778107d2334",
-                                "injection time": "2011-07-12T16:35:04+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 9,
-                                    "injection name": "Dosage Unit 1",
-                                    "injection position": "RB1",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RB2"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_36",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 12.750000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_37",
-                                                    "relative peak height": {
-                                                        "value": 40.34894510534425,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.10622303378582297,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0026117990654063047,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 37.81610105503127,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 10.240000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 85.67970119029833,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.784884335656394,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 332.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.489893052758996,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5125274922897276,
-                                                        "unit": "s"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7921827104097128
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 20.64,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_38",
-                                                    "relative peak height": {
-                                                        "value": 31.686660187964005,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08341861644507235,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002194014917307882,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.767026387328094,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.72,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 94.51847369712019,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6754060246615827,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 627.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5115339265583394,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.027673241170119,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5539202238162995,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2504001610860744,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.67820507372619
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 30.002,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_39",
-                                                    "relative peak height": {
-                                                        "value": 27.964394706691753,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07361934335516412,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002100765470322303,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 30.416872557640634,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.14,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.90905070834997,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1177.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5846690137216535,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.3632217686998533,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.688396780858077,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2376060633263086,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "93ac3fed-6147-4717-a6a8-6b5d169f542e",
-                                "injection time": "2011-07-12T16:35:50+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 10,
-                                    "injection name": "Dosage Unit 2",
-                                    "injection position": "RB2",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RB3"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_40",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_41",
-                                                    "relative peak height": {
-                                                        "value": 41.49848186460403,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11088799843208963,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030250093044811178,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 42.04181668099132,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 9.72,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.23500499664001,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7433371316630695,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 314.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5340500273702506,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2152474224880265,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5991944010024692,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2429515766789119,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7437195488170474
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 20.64,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_42",
-                                                    "relative peak height": {
-                                                        "value": 32.093222012591866,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.0857562251029818,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023302197867473944,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 32.38557744458143,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.879999999999999,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.38619878320794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6903172172920162,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 605.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5389069484783957,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6080649923787314,
-                                                        "unit": "s"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.695214860804459
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 30.002,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_43",
-                                                    "relative peak height": {
-                                                        "value": 26.408296122804103,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07056554764133181,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0018400101807433805,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 25.572605874427246,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.740000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 88.38382163813252,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1246.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5401351610383385,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.0309838427660885,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.601167193217554,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2344967852555495,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "b0432f5e-4f56-4d4b-a844-d3cacde03960",
-                                "injection time": "2011-07-12T16:36:35+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 11,
-                                    "injection name": "Dosage Unit 3",
-                                    "injection position": "RB3",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RB4"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_44",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_45",
-                                                    "relative peak height": {
-                                                        "value": 41.07468019828456,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11119161067151861,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030477351574798553,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.58699726408905,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 9.51,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.98052340960551,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.740847023634937,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.536914483159012,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.241613106797158,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.604780875808448,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2429191094451182,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7408423252069716
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 20.040000000000003,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_46",
-                                                    "relative peak height": {
-                                                        "value": 31.72825471954206,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08589027909727787,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002360248475208721,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.43166760102576,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 101.6798389394807,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.650602342653083,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 604.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.540438051134333,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2410591168577985,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6110849544989945,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2345401873992436,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6492481035473205
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 30.002,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_47",
-                                                    "relative peak height": {
-                                                        "value": 27.19706508217338,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07362407832334805,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0021011581194076284,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.981335134885185,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 20.73,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.927911379387,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1177.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5847383914808377,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.3638675345278446,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.688531937252503,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.237602783081184,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "f748e0eb-8168-4f06-9e96-2a8d75ffefae",
-                                "injection time": "2011-07-12T16:37:20+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 12,
-                                    "injection name": "Dosage Unit 4",
-                                    "injection position": "RB4",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RB5"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_48",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_49",
-                                                    "relative peak height": {
-                                                        "value": 41.281116975624,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11168532893211912,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030856740484843134,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 41.237012758952396,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.75,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 101.22510339579506,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7414104103164367,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 311.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.541072752153555,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.274686193800009,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6133005342662416,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2326636525976313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7412426300787887
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 18.71,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_50",
-                                                    "relative peak height": {
-                                                        "value": 31.62644460649842,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08556478427935824,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002325504087190442,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.078085438600628,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.18304577771963,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.65904599406423,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 608.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5352841871773215,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.180816162689157,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6013661888825834,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2144758398527444,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.658792313762178
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 30.002,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_51",
-                                                    "relative peak height": {
-                                                        "value": 27.092438417877574,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07329811104821975,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002071599694332889,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.684901802446973,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.42,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.50808957782804,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1184.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5799684329320796,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.320456030083756,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.67922678083812,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2378454118741702,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "6ce5b0a5-05e2-4f09-8b67-ec9c40b80ed0",
-                                "injection time": "2011-07-12T16:38:06+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 13,
-                                    "injection name": "Dosage Unit 5",
-                                    "injection position": "RB5",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RB6"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_52",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_53",
-                                                    "relative peak height": {
-                                                        "value": 41.31414034944879,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11180531684806054,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.003111761448391765,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 41.57749171119995,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 5.960000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 102.0808968825557,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7412055049093464,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 310.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5421212212470685,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2840719059345815,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.615367238567654,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2306435910376186,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.740979771724609
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 18.650000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_54",
-                                                    "relative peak height": {
-                                                        "value": 31.60334393668832,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08552572684346832,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002321580274574739,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.019564392670027,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.01400737393118,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6608748028931526,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 608.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5345977443749215,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.1729464177295448,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6000868106229236,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2111349728666854,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6606635927954727
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 25.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_55",
-                                                    "relative peak height": {
-                                                        "value": 27.082515713862897,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07329135314977982,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0020509035268582556,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.40294389613003,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.14,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 98.51396117907544,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1186.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5785137748116607,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2879683944556826,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6767922499307737,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2136076910692162,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "c1dd18dd-3fb5-4e50-8b6e-e95a06a47882",
-                                "injection time": "2011-07-12T16:38:51+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 14,
-                                    "injection name": "Dosage Unit 6",
-                                    "injection position": "RB6",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RB7"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_56",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_57",
-                                                    "relative peak height": {
-                                                        "value": 41.39982137685367,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11142461625108377,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030709707677926737,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 41.73274045443911,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 5.680000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.74276433960094,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7486648911997633,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5380579222026096,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.238978188809999,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6075836121929052,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2230214050017518,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7495471541221888
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 18.39,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_58",
-                                                    "relative peak height": {
-                                                        "value": 31.525201912016822,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08484779422860798,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0022732265303155724,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 30.89185145581615,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.370000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 97.93092121582738,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6753975569894504,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 616.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5255364960077378,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.09373208242312,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5823308057215777,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2015141700726726,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.677192009548953
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 25.48,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_59",
-                                                    "relative peak height": {
-                                                        "value": 27.074976711129494,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07287033590273688,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0020144633945566536,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.375408089744745,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.14,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 96.76358056296735,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1198.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.570676243799538,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.208197156377137,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.661969920532803,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.1888826766372835,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "bc5b432f-8b47-4e86-889e-0e3a0deae9b5",
-                                "injection time": "2011-07-12T16:39:36+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 15,
-                                    "injection name": "Dosage Unit 7",
-                                    "injection position": "RB7",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RB8"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_60",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 13.96,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_61",
-                                                    "relative peak height": {
-                                                        "value": 41.30700892747157,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11048838942705087,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002986527171581122,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 41.336289352689626,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 9.760000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 97.97260403643288,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7556022901555846,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 315.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5293084830868997,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.162271673882282,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5902295734962912,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2267071354510781,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7576977725711733
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 18.39,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_62",
-                                                    "relative peak height": {
-                                                        "value": 31.603023187189983,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08453207394196331,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0022552482085311347,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.214714333445567,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 13.96,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 97.15641256445238,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.684855788768713,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 618.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5221799035711259,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.0725221636354383,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5756186978579523,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2097204397456138,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6879874289445005
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 25.290000000000003,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_63",
-                                                    "relative peak height": {
-                                                        "value": 27.089967885338464,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07246050970519374,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.001983176879388989,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.448996313864807,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.14,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 95.26075095626354,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1210.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5631254728486987,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.142777768088494,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6476200155437413,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.169106443716203,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "4ea96e04-a9cd-490b-934f-5fee95ae0ca7",
-                                "injection time": "2011-07-12T16:40:21+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 16,
-                                    "injection name": "Dosage Unit 8",
-                                    "injection position": "RB8",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RC1"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_64",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.690000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_65",
-                                                    "relative peak height": {
-                                                        "value": 41.1657618960235,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11185134672580614,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0031126556539685132,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 41.01098690688492,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 7.630000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 102.11023117079911,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7349680799208416,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 310.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.543202312938482,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.3042158226373077,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6172819270770136,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2434756881211064,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7339906038336619
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 20.64,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_66",
-                                                    "relative peak height": {
-                                                        "value": 31.739380078444363,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08623895787433863,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023763880676600387,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.310247827840602,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.690000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 102.3751348704965,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.647154536553006,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 600.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5445778381778563,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2790061463910747,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.619193968423874,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2313828806414842,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6452680063735947
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 30.002,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_67",
-                                                    "relative peak height": {
-                                                        "value": 27.09485802553213,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07361934335516412,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002100765470322303,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.67876526527448,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.14,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.90905070834997,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1177.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5846690137216535,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.3632217686998533,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.688396780858077,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2376060633263086,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "80617da6-084a-4ecd-8549-67053685416e",
-                                "injection time": "2011-07-12T16:41:07+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 17,
-                                    "injection name": "Dosage Unit 9",
-                                    "injection position": "RC1",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RC2"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_68",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.879999999999999,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_69",
-                                                    "relative peak height": {
-                                                        "value": 41.230533368270166,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11231315585094342,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.003193813898644739,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 41.650661358875176,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 6.11,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 104.77261597868494,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7309749650844548,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 308.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5476023024271923,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.3517035911836155,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.625820771523254,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2431705731053309,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7294086271087814
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 20.64,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_70",
-                                                    "relative peak height": {
-                                                        "value": 31.743560630267083,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08647036991946239,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023735195145676907,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 30.95316780100753,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.879999999999999,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 102.25155719658505,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.644852974739308,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 598.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5473009215132072,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6245288900138855,
-                                                        "unit": "s"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.642611786755101
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 30.002,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_71",
-                                                    "relative peak height": {
-                                                        "value": 27.025906001462744,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.07361934335516412,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002100765470322303,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.396170840117303,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.14,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.90905070834997,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1177.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5846690137216535,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.3632217686998533,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.688396780858077,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2376060633263086,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "a2e1aa2b-20ff-452e-be39-f9ae32cca4f8",
-                                "injection time": "2011-07-12T16:41:52+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 18,
-                                    "injection name": "Dosage Unit 10",
-                                    "injection position": "RC2",
-                                    "injection status": "Finished",
-                                    "injection type": "Unknown",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RC3"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_72",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_73",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_74",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_75",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "516d0835-2490-4db3-9c2c-f186f296045c",
-                                "injection time": "2011-07-12T16:42:37+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 19,
-                                    "injection name": "Calibration Standard",
-                                    "injection position": "RC3",
-                                    "injection status": "Finished",
-                                    "injection type": "CalibrationStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RC4"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_76",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_77",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_78",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_79",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "3535b999-7056-478f-a61a-972e0e241eab",
-                                "injection time": "2011-07-12T16:43:22+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 20,
-                                    "injection name": "Calibration Standard",
-                                    "injection position": "RC4",
-                                    "injection status": "Finished",
-                                    "injection type": "CalibrationStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "HPLC",
-                                        "detection type": "single channel",
-                                        "detector wavelength setting": {
-                                            "value": 230.0,
-                                            "unit": "nm"
-                                        },
-                                        "detector bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference bandwidth setting": {
-                                            "value": 1.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 0.0,
-                                            "unit": "nm"
-                                        }
-                                    }
-                                ]
-                            },
-                            "sample document": {
-                                "sample identifier": "",
-                                "description": "",
-                                "location identifier": "RC5"
-                            },
-                            "chromatography column document": {
-                                "chromatography column serial number": "N/A"
-                            },
-                            "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_80",
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "peak list": {
-                                            "peak": [
-                                                {
-                                                    "peak end": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_81",
-                                                    "relative peak height": {
-                                                        "value": 41.19251735685675,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 1",
-                                                    "peak height": {
-                                                        "value": 0.11128958058334837,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0030483288680073542,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 40.9093439254137,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 11.540000000000001,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 8.86,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "1",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 1.7448475391025424,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 312.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5365257465210709,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.2219895839755237,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6043966565659544,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2188763229155313,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 1.7453679568237164
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 19.89,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_82",
-                                                    "relative peak height": {
-                                                        "value": 31.577429865305017,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 2",
-                                                    "peak height": {
-                                                        "value": 0.08531255555870823,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.0023212551276891066,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 31.151830550139536,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 16.080000000000002,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 14.38,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 99.99999999999999,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "2",
-                                                    "chromatographic peak resolution": {
-                                                        "value": 2.6572067373355894,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 609.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5337711590500946,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.187018179210211,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.5979447548829593,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2416718222238794,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "custom information document": {
-                                                        "chromatographic peak resolution (usp)": 2.6568677245626446
-                                                    }
-                                                },
-                                                {
-                                                    "peak end": {
-                                                        "value": 27.05,
-                                                        "unit": "s"
-                                                    },
-                                                    "identifier": "BENCHLING_CHROMELEON_TEST_ID_83",
-                                                    "relative peak height": {
-                                                        "value": 27.230052777838246,
-                                                        "unit": "%"
-                                                    },
-                                                    "written name": "Substance 3",
-                                                    "peak height": {
-                                                        "value": 0.0735672725863069,
-                                                        "unit": "mAU"
-                                                    },
-                                                    "peak area": {
-                                                        "value": 0.002081840484649877,
-                                                        "unit": "mAU.s"
-                                                    },
-                                                    "relative peak area": {
-                                                        "value": 27.938825524446756,
-                                                        "unit": "%"
-                                                    },
-                                                    "retention time": {
-                                                        "value": 23.1,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak start": {
-                                                        "value": 21.03,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak analyte amount": {
-                                                        "value": 100.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak index": "3",
-                                                    "number of theoretical plates by peak width at half height": {
-                                                        "value": 1179.0,
-                                                        "unit": "(unitless)"
-                                                    },
-                                                    "peak width at half height": {
-                                                        "value": 1.5836377664993173,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at 5 % of height": {
-                                                        "value": 3.348997896470387,
-                                                        "unit": "s"
-                                                    },
-                                                    "peak width at baseline": {
-                                                        "value": 2.6864733853958036,
-                                                        "unit": "s"
-                                                    },
-                                                    "asymmetry factor measured at 5 % height": {
-                                                        "value": 1.2325188419994737,
-                                                        "unit": "(unitless)"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "injection document": {
-                                "injection identifier": "d7b0c168-9fbf-4760-9737-8b9723930556",
-                                "injection time": "2011-07-12T16:44:07+01:00",
-                                "injection volume setting": {
-                                    "value": 10.0,
-                                    "unit": "μL"
-                                },
-                                "custom information document": {
-                                    "injection": 21,
-                                    "injection name": "Check Standard",
-                                    "injection position": "RC5",
-                                    "injection status": "Finished",
-                                    "injection type": "CheckStandard",
-                                    "last update user name": "anatoliy.kolesnick",
-                                    "creation user name": "anatoliy.kolesnick"
-                                }
-                            },
-                            "chromatogram data cube": {
-                                "label": "UV_VIS_1",
-                                "cube-structure": {
-                                    "dimensions": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "retention time",
-                                            "unit": "s"
-                                        }
-                                    ],
-                                    "measures": [
-                                        {
-                                            "@componentDatatype": "double",
-                                            "concept": "absorbance",
-                                            "unit": "mAU"
-                                        }
-                                    ]
-                                },
-                                "data": {
-                                    "dimensions": [
-                                        [
-                                            0.0,
-                                            0.010000000000000002,
-                                            0.020000000000000004,
-                                            0.03,
-                                            0.04000000000000001
-                                        ]
-                                    ],
-                                    "measures": [
-                                        [
-                                            0.0,
-                                            -1.0146761124737885e-08,
-                                            -7.111027239027897e-08,
-                                            -2.3425987111285345e-07,
-                                            -4.954396381502703e-07
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
-        ],
-        "data system document": {
-            "ASM converter name": "allotropy_benchling_thermo_fisher_scientific_chromeleon",
-            "ASM converter version": "0.1.75",
-            "file name": "chromeleon_example.json",
-            "software name": "Thermo Fisher Scientific Chromeleon",
-            "UNC path": "tests/parsers/benchling_chromeleon/testdata/input/chromeleon_example.json"
+  "$asm.manifest": "http://purl.allotrope.org/manifests/liquid-chromatography/BENCHLING/2023/09/liquid-chromatography.manifest",
+  "liquid chromatography aggregate document": {
+    "data system document": {
+      "ASM converter name": "allotropy_benchling_thermo_fisher_scientific_chromeleon",
+      "ASM converter version": "0.1.128",
+      "file name": "chromeleon_example.json",
+      "software name": "Thermo Fisher Scientific Chromeleon",
+      "UNC path": "tests/parsers/benchling_chromeleon/testdata/input/chromeleon_example.json"
+    },
+    "device system document": {
+      "asset management identifier": "N/A",
+      "device document": [
+        {
+          "device type": "pump",
+          "model number": "HPG-3200RS"
         },
-        "device system document": {
-            "asset management identifier": "N/A",
-            "device document": [
-                {
-                    "device type": "pump",
-                    "model number": "HPG-3200RS"
-                },
-                {
-                    "device type": "uv",
-                    "model number": "DAD-3000RS"
-                },
-                {
-                    "device type": "sampler",
-                    "model number": "N/A"
-                }
-            ]
+        {
+          "device type": "uv",
+          "model number": "DAD-3000RS"
         },
-        "custom information document": {
-            "Sequence Creation Time": "2024-10-21T12:15:44.51+02:00",
-            "Sequence Directory": "Suppositories - 3 Peaks",
-            "Sequence Name": "Content Uniformity Stage 1 (10 units) 2011-08-17 15-34-22",
-            "Sequence Update operator": "anatoliy.kolesnick",
-            "Sequence Update Time": "2024-10-21T12:15:44.51+02:00"
+        {
+          "device type": "sampler",
+          "model number": "N/A"
         }
+      ]
+    },
+    "liquid chromatography document": [
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RA1",
+                "written name": "Blank"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_0",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_1",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_2",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_3",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "bee79522-5ead-406e-a656-66534b588357",
+                "injection time": "2011-07-15T16:27:39+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 1,
+                  "injection name": "Blank",
+                  "injection position": "RA1",
+                  "injection status": "Finished",
+                  "injection type": "Blank",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RA2",
+                "written name": "SST Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_4",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_5",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_6",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_7",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "b643326f-e8ea-44a0-9257-16a885f4baa3",
+                "injection time": "2011-07-15T16:28:24+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 2,
+                  "injection name": "SST Standard",
+                  "injection position": "RA2",
+                  "injection status": "Finished",
+                  "injection type": "CheckStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RA3",
+                "written name": "SST Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_8",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_9",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_10",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_11",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "a9df04e0-fa0b-4619-a598-6b68a6961c13",
+                "injection time": "2011-07-15T16:29:09+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 3,
+                  "injection name": "SST Standard",
+                  "injection position": "RA3",
+                  "injection status": "Finished",
+                  "injection type": "CheckStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RA4",
+                "written name": "SST Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_12",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_13",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_14",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_15",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "56c3c2e1-2ef5-4ef5-95aa-7d14cee8b6f5",
+                "injection time": "2011-07-12T16:31:17+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 4,
+                  "injection name": "SST Standard",
+                  "injection position": "RA4",
+                  "injection status": "Finished",
+                  "injection type": "CheckStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RA5",
+                "written name": "SST Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_16",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_17",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_18",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_19",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "514dca95-4e3c-4422-a75e-bfed635c308b",
+                "injection time": "2011-07-12T16:32:03+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 5,
+                  "injection name": "SST Standard",
+                  "injection position": "RA5",
+                  "injection status": "Finished",
+                  "injection type": "CheckStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RA6",
+                "written name": "SST Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_20",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_21",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_22",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_23",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "4c5b6a6d-6f57-4123-98f4-8217f8c48351",
+                "injection time": "2011-07-12T16:32:49+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 6,
+                  "injection name": "SST Standard",
+                  "injection position": "RA6",
+                  "injection status": "Finished",
+                  "injection type": "CheckStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RA7",
+                "written name": "Calibration Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_24",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_25",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_26",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_27",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "5a6636fe-24b0-4094-96ba-d96a62aa3355",
+                "injection time": "2011-07-12T16:33:34+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 7,
+                  "injection name": "Calibration Standard",
+                  "injection position": "RA7",
+                  "injection status": "Finished",
+                  "injection type": "CalibrationStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RA8",
+                "written name": "Calibration Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_28",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_29",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_30",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_31",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "4848ed9c-2128-45d8-b4f0-1d3d849aaa4e",
+                "injection time": "2011-07-12T16:34:19+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 8,
+                  "injection name": "Calibration Standard",
+                  "injection position": "RA8",
+                  "injection status": "Finished",
+                  "injection type": "CalibrationStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RB1",
+                "written name": "Dosage Unit 1"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_32",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_33",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_34",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_35",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "b67cdd52-c9db-447a-9369-e778107d2334",
+                "injection time": "2011-07-12T16:35:04+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 9,
+                  "injection name": "Dosage Unit 1",
+                  "injection position": "RB1",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RB2",
+                "written name": "Dosage Unit 2"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_36",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 12.750000000000002,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_37",
+                          "relative peak height": {
+                            "value": 40.34894510534425,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.10622303378582297,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0026117990654063047,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 37.81610105503127,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 10.240000000000002,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 85.67970119029833,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.784884335656394,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 332.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.489893052758996,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5125274922897276,
+                            "unit": "s"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7921827104097128
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 20.64,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_38",
+                          "relative peak height": {
+                            "value": 31.686660187964005,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08341861644507235,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002194014917307882,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.767026387328094,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.72,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 94.51847369712019,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6754060246615827,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 627.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5115339265583394,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.027673241170119,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5539202238162995,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2504001610860744,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.67820507372619
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 30.002,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_39",
+                          "relative peak height": {
+                            "value": 27.964394706691753,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07361934335516412,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002100765470322303,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 30.416872557640634,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.14,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.90905070834997,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1177.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5846690137216535,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.3632217686998533,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.688396780858077,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2376060633263086,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "93ac3fed-6147-4717-a6a8-6b5d169f542e",
+                "injection time": "2011-07-12T16:35:50+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 10,
+                  "injection name": "Dosage Unit 2",
+                  "injection position": "RB2",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RB3",
+                "written name": "Dosage Unit 3"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_40",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_41",
+                          "relative peak height": {
+                            "value": 41.49848186460403,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11088799843208963,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030250093044811178,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 42.04181668099132,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 9.72,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.23500499664001,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7433371316630695,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 314.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5340500273702506,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2152474224880265,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5991944010024692,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2429515766789119,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7437195488170474
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 20.64,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_42",
+                          "relative peak height": {
+                            "value": 32.093222012591866,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.0857562251029818,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023302197867473944,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 32.38557744458143,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.879999999999999,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.38619878320794,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6903172172920162,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 605.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5389069484783957,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6080649923787314,
+                            "unit": "s"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.695214860804459
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 30.002,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_43",
+                          "relative peak height": {
+                            "value": 26.408296122804103,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07056554764133181,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0018400101807433805,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 25.572605874427246,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.740000000000002,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 88.38382163813252,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1246.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5401351610383385,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.0309838427660885,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.601167193217554,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2344967852555495,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "b0432f5e-4f56-4d4b-a844-d3cacde03960",
+                "injection time": "2011-07-12T16:36:35+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 11,
+                  "injection name": "Dosage Unit 3",
+                  "injection position": "RB3",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RB4",
+                "written name": "Dosage Unit 4"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_44",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_45",
+                          "relative peak height": {
+                            "value": 41.07468019828456,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11119161067151861,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030477351574798553,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.58699726408905,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 9.51,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.98052340960551,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.740847023634937,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.536914483159012,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.241613106797158,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.604780875808448,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2429191094451182,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7408423252069716
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 20.040000000000003,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_46",
+                          "relative peak height": {
+                            "value": 31.72825471954206,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08589027909727787,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002360248475208721,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.43166760102576,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 101.6798389394807,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.650602342653083,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 604.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.540438051134333,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2410591168577985,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6110849544989945,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2345401873992436,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6492481035473205
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 30.002,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_47",
+                          "relative peak height": {
+                            "value": 27.19706508217338,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07362407832334805,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0021011581194076284,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.981335134885185,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 20.73,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.927911379387,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1177.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5847383914808377,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.3638675345278446,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.688531937252503,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.237602783081184,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "f748e0eb-8168-4f06-9e96-2a8d75ffefae",
+                "injection time": "2011-07-12T16:37:20+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 12,
+                  "injection name": "Dosage Unit 4",
+                  "injection position": "RB4",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RB5",
+                "written name": "Dosage Unit 5"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_48",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_49",
+                          "relative peak height": {
+                            "value": 41.281116975624,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11168532893211912,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030856740484843134,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 41.237012758952396,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.75,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 101.22510339579506,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7414104103164367,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 311.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.541072752153555,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.274686193800009,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6133005342662416,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2326636525976313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7412426300787887
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 18.71,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_50",
+                          "relative peak height": {
+                            "value": 31.62644460649842,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08556478427935824,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002325504087190442,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.078085438600628,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.18304577771963,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.65904599406423,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 608.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5352841871773215,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.180816162689157,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6013661888825834,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2144758398527444,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.658792313762178
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 30.002,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_51",
+                          "relative peak height": {
+                            "value": 27.092438417877574,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07329811104821975,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002071599694332889,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.684901802446973,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.42,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.50808957782804,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1184.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5799684329320796,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.320456030083756,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.67922678083812,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2378454118741702,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "6ce5b0a5-05e2-4f09-8b67-ec9c40b80ed0",
+                "injection time": "2011-07-12T16:38:06+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 13,
+                  "injection name": "Dosage Unit 5",
+                  "injection position": "RB5",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RB6",
+                "written name": "Dosage Unit 6"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_52",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_53",
+                          "relative peak height": {
+                            "value": 41.31414034944879,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11180531684806054,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.003111761448391765,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 41.57749171119995,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 5.960000000000001,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 102.0808968825557,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7412055049093464,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 310.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5421212212470685,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2840719059345815,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.615367238567654,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2306435910376186,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.740979771724609
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 18.650000000000002,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_54",
+                          "relative peak height": {
+                            "value": 31.60334393668832,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08552572684346832,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002321580274574739,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.019564392670027,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.01400737393118,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6608748028931526,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 608.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5345977443749215,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.1729464177295448,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6000868106229236,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2111349728666854,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6606635927954727
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 25.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_55",
+                          "relative peak height": {
+                            "value": 27.082515713862897,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07329135314977982,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0020509035268582556,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.40294389613003,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.14,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 98.51396117907544,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1186.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5785137748116607,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2879683944556826,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6767922499307737,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2136076910692162,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "c1dd18dd-3fb5-4e50-8b6e-e95a06a47882",
+                "injection time": "2011-07-12T16:38:51+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 14,
+                  "injection name": "Dosage Unit 6",
+                  "injection position": "RB6",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RB7",
+                "written name": "Dosage Unit 7"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_56",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_57",
+                          "relative peak height": {
+                            "value": 41.39982137685367,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11142461625108377,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030709707677926737,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 41.73274045443911,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 5.680000000000001,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.74276433960094,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7486648911997633,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5380579222026096,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.238978188809999,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6075836121929052,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2230214050017518,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7495471541221888
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 18.39,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_58",
+                          "relative peak height": {
+                            "value": 31.525201912016822,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08484779422860798,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0022732265303155724,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 30.89185145581615,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.370000000000001,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 97.93092121582738,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6753975569894504,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 616.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5255364960077378,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.09373208242312,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5823308057215777,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2015141700726726,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.677192009548953
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 25.48,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_59",
+                          "relative peak height": {
+                            "value": 27.074976711129494,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07287033590273688,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0020144633945566536,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.375408089744745,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.14,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 96.76358056296735,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1198.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.570676243799538,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.208197156377137,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.661969920532803,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.1888826766372835,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "bc5b432f-8b47-4e86-889e-0e3a0deae9b5",
+                "injection time": "2011-07-12T16:39:36+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 15,
+                  "injection name": "Dosage Unit 7",
+                  "injection position": "RB7",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RB8",
+                "written name": "Dosage Unit 8"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_60",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 13.96,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_61",
+                          "relative peak height": {
+                            "value": 41.30700892747157,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11048838942705087,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002986527171581122,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 41.336289352689626,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 9.760000000000002,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 97.97260403643288,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7556022901555846,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 315.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5293084830868997,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.162271673882282,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5902295734962912,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2267071354510781,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7576977725711733
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 18.39,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_62",
+                          "relative peak height": {
+                            "value": 31.603023187189983,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08453207394196331,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0022552482085311347,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.214714333445567,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 13.96,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 97.15641256445238,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.684855788768713,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 618.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5221799035711259,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.0725221636354383,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5756186978579523,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2097204397456138,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6879874289445005
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 25.290000000000003,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_63",
+                          "relative peak height": {
+                            "value": 27.089967885338464,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07246050970519374,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.001983176879388989,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.448996313864807,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.14,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 95.26075095626354,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1210.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5631254728486987,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.142777768088494,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6476200155437413,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.169106443716203,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "4ea96e04-a9cd-490b-934f-5fee95ae0ca7",
+                "injection time": "2011-07-12T16:40:21+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 16,
+                  "injection name": "Dosage Unit 8",
+                  "injection position": "RB8",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RC1",
+                "written name": "Dosage Unit 9"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_64",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.690000000000001,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_65",
+                          "relative peak height": {
+                            "value": 41.1657618960235,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11185134672580614,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0031126556539685132,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 41.01098690688492,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 7.630000000000001,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 102.11023117079911,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7349680799208416,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 310.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.543202312938482,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.3042158226373077,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6172819270770136,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2434756881211064,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7339906038336619
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 20.64,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_66",
+                          "relative peak height": {
+                            "value": 31.739380078444363,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08623895787433863,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023763880676600387,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.310247827840602,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.690000000000001,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 102.3751348704965,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.647154536553006,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 600.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5445778381778563,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2790061463910747,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.619193968423874,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2313828806414842,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6452680063735947
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 30.002,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_67",
+                          "relative peak height": {
+                            "value": 27.09485802553213,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07361934335516412,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002100765470322303,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.67876526527448,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.14,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.90905070834997,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1177.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5846690137216535,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.3632217686998533,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.688396780858077,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2376060633263086,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "80617da6-084a-4ecd-8549-67053685416e",
+                "injection time": "2011-07-12T16:41:07+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 17,
+                  "injection name": "Dosage Unit 9",
+                  "injection position": "RC1",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RC2",
+                "written name": "Dosage Unit 10"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_68",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.879999999999999,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_69",
+                          "relative peak height": {
+                            "value": 41.230533368270166,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11231315585094342,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.003193813898644739,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 41.650661358875176,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 6.11,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 104.77261597868494,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7309749650844548,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 308.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5476023024271923,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.3517035911836155,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.625820771523254,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2431705731053309,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7294086271087814
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 20.64,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_70",
+                          "relative peak height": {
+                            "value": 31.743560630267083,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08647036991946239,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023735195145676907,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 30.95316780100753,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.879999999999999,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 102.25155719658505,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.644852974739308,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 598.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5473009215132072,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6245288900138855,
+                            "unit": "s"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.642611786755101
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 30.002,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_71",
+                          "relative peak height": {
+                            "value": 27.025906001462744,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.07361934335516412,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002100765470322303,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.396170840117303,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.14,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.90905070834997,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1177.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5846690137216535,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.3632217686998533,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.688396780858077,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2376060633263086,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "a2e1aa2b-20ff-452e-be39-f9ae32cca4f8",
+                "injection time": "2011-07-12T16:41:52+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 18,
+                  "injection name": "Dosage Unit 10",
+                  "injection position": "RC2",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RC3",
+                "written name": "Calibration Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_72",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_73",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_74",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_75",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "516d0835-2490-4db3-9c2c-f186f296045c",
+                "injection time": "2011-07-12T16:42:37+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 19,
+                  "injection name": "Calibration Standard",
+                  "injection position": "RC3",
+                  "injection status": "Finished",
+                  "injection type": "CalibrationStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RC4",
+                "written name": "Calibration Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_76",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_77",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_78",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_79",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "3535b999-7056-478f-a61a-972e0e241eab",
+                "injection time": "2011-07-12T16:43:22+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 20,
+                  "injection name": "Calibration Standard",
+                  "injection position": "RC4",
+                  "injection status": "Finished",
+                  "injection type": "CalibrationStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 230.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference bandwidth setting": {
+                      "value": 1.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 0.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "RC5",
+                "written name": "Check Standard"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_80",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_81",
+                          "relative peak height": {
+                            "value": 41.19251735685675,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 1",
+                          "peak height": {
+                            "value": 0.11128958058334837,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0030483288680073542,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 40.9093439254137,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 11.540000000000001,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 8.86,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.7448475391025424,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 312.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5365257465210709,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.2219895839755237,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6043966565659544,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2188763229155313,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 1.7453679568237164
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 19.89,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_82",
+                          "relative peak height": {
+                            "value": 31.577429865305017,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 2",
+                          "peak height": {
+                            "value": 0.08531255555870823,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.0023212551276891066,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 31.151830550139536,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 16.080000000000002,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 14.38,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 99.99999999999999,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "2",
+                          "chromatographic peak resolution": {
+                            "value": 2.6572067373355894,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 609.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5337711590500946,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.187018179210211,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.5979447548829593,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2416718222238794,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "chromatographic peak resolution (usp)": 2.6568677245626446
+                          }
+                        },
+                        {
+                          "peak end": {
+                            "value": 27.05,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_83",
+                          "relative peak height": {
+                            "value": 27.230052777838246,
+                            "unit": "%"
+                          },
+                          "written name": "Substance 3",
+                          "peak height": {
+                            "value": 0.0735672725863069,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 0.002081840484649877,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 27.938825524446756,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 23.1,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 21.03,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 100.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "3",
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 1179.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 1.5836377664993173,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 3.348997896470387,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 2.6864733853958036,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2325188419994737,
+                            "unit": "(unitless)"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "d7b0c168-9fbf-4760-9737-8b9723930556",
+                "injection time": "2011-07-12T16:44:07+01:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 21,
+                  "injection name": "Check Standard",
+                  "injection position": "RC5",
+                  "injection status": "Finished",
+                  "injection type": "CheckStandard",
+                  "last update user name": "anatoliy.kolesnick",
+                  "creation user name": "anatoliy.kolesnick"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      -1.0146761124737885e-08,
+                      -7.111027239027897e-08,
+                      -2.3425987111285345e-07,
+                      -4.954396381502703e-07
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      0.010000000000000002,
+                      0.020000000000000004,
+                      0.03,
+                      0.04000000000000001
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "anatoliy.kolesnick",
+        "submitter": "anatoliy.kolesnick"
+      }
+    ],
+    "custom information document": {
+      "Sequence Creation Time": "2024-10-21T12:15:44.51+02:00",
+      "Sequence Directory": "Suppositories - 3 Peaks",
+      "Sequence Name": "Content Uniformity Stage 1 (10 units) 2011-08-17 15-34-22",
+      "Sequence Update operator": "anatoliy.kolesnick",
+      "Sequence Update Time": "2024-10-21T12:15:44.51+02:00"
     }
+  }
 }

--- a/tests/parsers/benchling_chromeleon/testdata/output/chromeleon_example_multi_signal.json
+++ b/tests/parsers/benchling_chromeleon/testdata/output/chromeleon_example_multi_signal.json
@@ -1,0 +1,263 @@
+{
+  "$asm.manifest": "http://purl.allotrope.org/manifests/liquid-chromatography/BENCHLING/2023/09/liquid-chromatography.manifest",
+  "liquid chromatography aggregate document": {
+    "data system document": {
+      "ASM converter name": "allotropy_benchling_thermo_fisher_scientific_chromeleon",
+      "ASM converter version": "0.1.128",
+      "file name": "chromeleon_example_multi_signal.json",
+      "software name": "Thermo Fisher Scientific Chromeleon",
+      "UNC path": "tests/parsers/benchling_chromeleon/testdata/input/chromeleon_example_multi_signal.json"
+    },
+    "device system document": {
+      "asset management identifier": "VF-A10-A",
+      "device document": [
+        {
+          "device type": "pump",
+          "model number": "VF-P10-A"
+        },
+        {
+          "device type": "uv",
+          "model number": "VF-D40-A"
+        },
+        {
+          "device type": "sampler",
+          "model number": "VF-A10-A"
+        }
+      ]
+    },
+    "liquid chromatography document": [
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_1",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 220.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 4.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "B:A1",
+                "written name": "MQW"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_0",
+              "injection document": {
+                "injection identifier": "99999999-8888-7777-6666-555555555555",
+                "injection time": "2026-02-14T21:52:50+01:00",
+                "injection volume setting": {
+                  "value": 4.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 1,
+                  "injection name": "MQW",
+                  "injection position": "B:A1",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "Instrument Controller",
+                  "creation user name": "PD01",
+                  "ColumnValvePosition": 1.0
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      0.5,
+                      1.0,
+                      0.5,
+                      0.0
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      30.0,
+                      60.0,
+                      90.0,
+                      120.0
+                    ]
+                  ]
+                }
+              }
+            },
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "UV_VIS_2",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 280.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 4.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "",
+                "description": "",
+                "location identifier": "B:A1",
+                "written name": "MQW"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_1",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 96.0,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_2",
+                          "relative peak height": {
+                            "value": 100.0,
+                            "unit": "%"
+                          },
+                          "written name": "Peak1",
+                          "peak height": {
+                            "value": 0.8,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 8.0,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 100.0,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 60.0,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 24.0,
+                            "unit": "s"
+                          },
+                          "peak index": "1",
+                          "peak width at half height": {
+                            "value": 36.0,
+                            "unit": "s"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "99999999-8888-7777-6666-555555555555",
+                "injection time": "2026-02-14T21:52:50+01:00",
+                "injection volume setting": {
+                  "value": 4.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 1,
+                  "injection name": "MQW",
+                  "injection position": "B:A1",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "Instrument Controller",
+                  "creation user name": "PD01",
+                  "ColumnValvePosition": 1.0
+                }
+              },
+              "chromatogram data cube": {
+                "label": "UV_VIS_2",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      0.3,
+                      0.8,
+                      0.3,
+                      0.0
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      30.0,
+                      60.0,
+                      90.0,
+                      120.0
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "Instrument Controller",
+        "submitter": "PD01"
+      }
+    ],
+    "custom information document": {
+      "Sequence Creation Time": "2026-02-13T10:00:00+01:00",
+      "Sequence Directory": "ChromeleonLocal",
+      "Sequence Name": "Test_MultiSignal",
+      "Sequence Update operator": "operator1",
+      "Sequence Update Time": "2026-02-14T15:00:00+01:00"
+    }
+  }
+}

--- a/tests/parsers/benchling_chromeleon/testdata/output/chromeleon_example_null_device_info.json
+++ b/tests/parsers/benchling_chromeleon/testdata/output/chromeleon_example_null_device_info.json
@@ -1,0 +1,369 @@
+{
+  "$asm.manifest": "http://purl.allotrope.org/manifests/liquid-chromatography/BENCHLING/2023/09/liquid-chromatography.manifest",
+  "liquid chromatography aggregate document": {
+    "data system document": {
+      "ASM converter name": "allotropy_benchling_thermo_fisher_scientific_chromeleon",
+      "ASM converter version": "0.1.128",
+      "file name": "chromeleon_example_null_device_info.json",
+      "software name": "Thermo Fisher Scientific Chromeleon",
+      "UNC path": "tests/parsers/benchling_chromeleon/testdata/input/chromeleon_example_null_device_info.json"
+    },
+    "device system document": {
+      "asset management identifier": "N/A"
+    },
+    "liquid chromatography document": [
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "FLD1_Signal_A",
+                    "detection type": "single channel",
+                    "detector wavelength setting": {
+                      "value": 280.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "SAMPLE-001",
+                "description": "test description",
+                "location identifier": "P1:A1",
+                "written name": "Blank Conditioning"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_0",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 21.0,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_1",
+                          "relative peak height": {
+                            "value": 100.0,
+                            "unit": "%"
+                          },
+                          "written name": "Peak1",
+                          "peak height": {
+                            "value": 3.2,
+                            "unit": "mAU"
+                          },
+                          "peak area": {
+                            "value": 5.0,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 100.0,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 12.0,
+                            "unit": "s"
+                          },
+                          "peak start": {
+                            "value": 3.0,
+                            "unit": "s"
+                          },
+                          "peak index": "1",
+                          "peak width at half height": {
+                            "value": 6.0,
+                            "unit": "s"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "injection time": "2024-09-23T08:05:00-07:00",
+                "injection volume setting": {
+                  "value": 5.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 1,
+                  "injection name": "Blank Conditioning",
+                  "injection position": "P1:A1",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "Instrument Controller",
+                  "creation user name": "testuser",
+                  "Analysis Type": "Laboratory Reagent Blank (LRB)",
+                  "Fortified": "LFB Set"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "FLD1_Signal_A",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.0,
+                      1.5,
+                      3.2,
+                      2.1,
+                      0.5
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      6.0,
+                      12.0,
+                      18.0,
+                      24.0
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "Instrument Controller",
+        "submitter": "testuser"
+      },
+      {
+        "measurement aggregate document": {
+          "measurement document": [
+            {
+              "device control aggregate document": {
+                "device control document": [
+                  {
+                    "device type": "CD_1",
+                    "detection type": "single channel",
+                    "detector sampling rate setting": {
+                      "value": 2.5,
+                      "unit": "Hz"
+                    },
+                    "detector wavelength setting": {
+                      "value": 254.0,
+                      "unit": "nm"
+                    },
+                    "detector bandwidth setting": {
+                      "value": 4.0,
+                      "unit": "nm"
+                    },
+                    "electronic absorbance reference wavelength setting": {
+                      "value": 360.0,
+                      "unit": "nm"
+                    }
+                  }
+                ]
+              },
+              "sample document": {
+                "sample identifier": "STD-001",
+                "description": "",
+                "location identifier": "P1:A2",
+                "written name": "Standard 1"
+              },
+              "chromatography column document": {
+                "chromatography column serial number": "N/A"
+              },
+              "measurement identifier": "BENCHLING_CHROMELEON_TEST_ID_2",
+              "processed data aggregate document": {
+                "processed data document": [
+                  {
+                    "peak list": {
+                      "peak": [
+                        {
+                          "peak end": {
+                            "value": 25.2,
+                            "unit": "s"
+                          },
+                          "identifier": "BENCHLING_CHROMELEON_TEST_ID_3",
+                          "relative peak height": {
+                            "value": 100.0,
+                            "unit": "%"
+                          },
+                          "written name": "Analyte1",
+                          "peak height": {
+                            "value": 5.5,
+                            "unit": "mAU"
+                          },
+                          "capacity factor (chromatography)": {
+                            "value": 2.5,
+                            "unit": "(unitless)"
+                          },
+                          "baseline value at start of peak": {
+                            "value": 0.6,
+                            "unit": "s"
+                          },
+                          "baseline value at end of peak": {
+                            "value": 1.2,
+                            "unit": "s"
+                          },
+                          "peak group": {
+                            "value": 900000.0,
+                            "unit": "mAU.s"
+                          },
+                          "relative corrected peak area": {
+                            "value": 95.0,
+                            "unit": "%"
+                          },
+                          "peak area": {
+                            "value": 12.0,
+                            "unit": "mAU.s"
+                          },
+                          "relative peak area": {
+                            "value": 100.0,
+                            "unit": "%"
+                          },
+                          "retention time": {
+                            "value": 12.0,
+                            "unit": "s"
+                          },
+                          "relative retention time": {
+                            "value": 1.0,
+                            "unit": "%"
+                          },
+                          "peak start": {
+                            "value": 4.8,
+                            "unit": "s"
+                          },
+                          "peak analyte amount": {
+                            "value": 50.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak index": "1",
+                          "chromatographic peak resolution": {
+                            "value": 1.8,
+                            "unit": "(unitless)"
+                          },
+                          "number of theoretical plates by peak width at half height": {
+                            "value": 500.0,
+                            "unit": "(unitless)"
+                          },
+                          "peak width at half height": {
+                            "value": 9.0,
+                            "unit": "s"
+                          },
+                          "peak width at 5 % of height": {
+                            "value": 15.0,
+                            "unit": "s"
+                          },
+                          "peak width at baseline": {
+                            "value": 20.400000000000002,
+                            "unit": "s"
+                          },
+                          "peak width at 10 % of height": {
+                            "value": 13.2,
+                            "unit": "s"
+                          },
+                          "asymmetry factor measured at 5 % height": {
+                            "value": 1.2,
+                            "unit": "(unitless)"
+                          },
+                          "custom information document": {
+                            "peak right width at 10% height": 7.199999999999999,
+                            "peak left width at 10% height": 6.0,
+                            "chromatographic peak resolution (usp)": 1.75,
+                            "asymmetry aia": 1.1
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "injection document": {
+                "injection identifier": "11111111-2222-3333-4444-555555555555",
+                "injection time": "2024-09-23T08:15:00-07:00",
+                "injection volume setting": {
+                  "value": 10.0,
+                  "unit": "\u03bcL"
+                },
+                "custom information document": {
+                  "injection": 2,
+                  "injection name": "Standard 1",
+                  "injection position": "P1:A2",
+                  "injection status": "Finished",
+                  "injection type": "Unknown",
+                  "last update user name": "labuser",
+                  "creation user name": "admin",
+                  "Analysis Type": "Calibration Standard"
+                }
+              },
+              "chromatogram data cube": {
+                "label": "CD_1",
+                "cube-structure": {
+                  "dimensions": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "retention time",
+                      "unit": "s"
+                    }
+                  ],
+                  "measures": [
+                    {
+                      "@componentDatatype": "double",
+                      "concept": "absorbance",
+                      "unit": "mAU"
+                    }
+                  ]
+                },
+                "data": {
+                  "measures": [
+                    [
+                      0.1,
+                      2.0,
+                      5.5,
+                      4.0,
+                      1.2,
+                      0.2
+                    ]
+                  ],
+                  "dimensions": [
+                    [
+                      0.0,
+                      6.0,
+                      12.0,
+                      18.0,
+                      24.0,
+                      30.0
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "analyst": "labuser",
+        "submitter": "admin"
+      }
+    ],
+    "custom information document": {
+      "Sequence Creation Time": "2024-09-23T08:00:00-07:00",
+      "Sequence Directory": "ChromeleonLocal",
+      "Sequence Name": "Test_Null_DeviceInfo",
+      "Sequence Update operator": "testuser",
+      "Sequence Update Time": "2024-09-23T09:00:00-07:00"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes crash when `device_information` is `null` in raw JSON (Glycans sequence)
- Maps `analyst` and `submitter` per LC document from injection-level fields
- Maps `injection name` → `sample document.written name`
- Uses `signal name` as `device type` instead of hardcoded "HPLC"
- Uses `sampler model number` as `asset management identifier` when available
- Merges non-null custom variables into injection custom info

## Context

The Chromeleon adapter is migrating from producing ASM directly to producing a raw JSON dump parsed by the allotropy `BENCHLING_CHROMELEON` parser. The raw JSON contains all the data but several critical fields were not being mapped into ASM output. This PR closes all mapping gaps so the new pipeline produces equivalent output to the old adapter.

## Test plan

- [x] All 8 production sequences from output.zip parse successfully (including previously-crashing Glycans)
- [x] No data loss in existing test output (verified via DeepDiff)
- [x] New test cases added: null device_information + custom variables + non-UV signals, and multi-signal + valid sampler model
- [x] Other parsers using same schema mapper (cytiva_unicorn, benchling_empower, agilent_openlab_cds) still pass
- [x] Vendor discovery tests pass (313 tests)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)