### PR TITLE
fix: Report Peak of Interest data as calculated data in Stunner parser

### DIFF
--- a/src/allotropy/parsers/unchained_labs_lunatic_stunner/constants.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic_stunner/constants.py
@@ -128,6 +128,7 @@ CALCULATED_DATA_LOOKUP: dict[str, list[dict[str, str | list[str]]]] = {
         },
         {
             "column": "peak of interest mean dia (nm)",
+            "alt_columns": ["pkoi intensity mean dia. (nm)"],
             "name": "Peak of Interest Mean Diameter",
             "feature": "dynamic light scattering",
             "unit": "nm",
@@ -140,18 +141,21 @@ CALCULATED_DATA_LOOKUP: dict[str, list[dict[str, str | list[str]]]] = {
         },
         {
             "column": "peak of interest est. mw (kda)",
+            "alt_columns": ["pkoi est. mw (kda)"],
             "name": "Peak of Interest Est. MW",
             "feature": "dynamic light scattering",
             "unit": "kDa",
         },
         {
             "column": "peak of interest intensity (%)",
+            "alt_columns": ["pkoi intensity area (%)"],
             "name": "Peak of Interest Intensity",
             "feature": "dynamic light scattering",
             "unit": "%",
         },
         {
             "column": "peak of interest mass (%)",
+            "alt_columns": ["pkoi mass area (%)"],
             "name": "Peak of Interest Mass",
             "feature": "dynamic light scattering",
             "unit": "%",
@@ -159,6 +163,20 @@ CALCULATED_DATA_LOOKUP: dict[str, list[dict[str, str | list[str]]]] = {
         {
             "column": "peak of interest diffusion coefficient (um^2/s)",
             "name": "Peak of Interest Diffusion coefficient",
+            "feature": "dynamic light scattering",
+            "unit": UNITLESS,
+        },
+        {
+            "column": "peak of interest mass mean dia (nm)",
+            "alt_columns": ["pkoi mass mean dia. (nm)"],
+            "name": "Peak of Interest Mass Mean Diameter",
+            "feature": "dynamic light scattering",
+            "unit": "nm",
+        },
+        {
+            "column": "peak of interest rayleigh ratio r (cm^-1)",
+            "alt_columns": ["pkoi rayleigh ratio r (1/km)"],
+            "name": "Peak of Interest Rayleigh Ratio R",
             "feature": "dynamic light scattering",
             "unit": UNITLESS,
         },

--- a/src/allotropy/parsers/unchained_labs_lunatic_stunner/unchained_labs_lunatic_stunner_calcdocs.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic_stunner/unchained_labs_lunatic_stunner_calcdocs.py
@@ -198,6 +198,20 @@ def create_calculated_data(
                 source_configs=(dynamic_light_scattering_conf,),
             ),
             CalculatedDataConfig(
+                name="Peak of Interest Mass Mean Diameter",
+                value="peak of interest mass mean dia (nm)",
+                unit="nm",
+                view_data=detection_type_view,
+                source_configs=(dynamic_light_scattering_conf,),
+            ),
+            CalculatedDataConfig(
+                name="Peak of Interest Rayleigh Ratio R",
+                value="peak of interest rayleigh ratio r (cm^-1)",
+                unit=UNITLESS,
+                view_data=detection_type_view,
+                source_configs=(dynamic_light_scattering_conf,),
+            ),
+            CalculatedDataConfig(
                 name="Derived intensity (cps)",
                 value="derived intensity (cps)",
                 unit=UNITLESS,

--- a/src/allotropy/parsers/unchained_labs_lunatic_stunner/unchained_labs_lunatic_stunner_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic_stunner/unchained_labs_lunatic_stunner_structure.py
@@ -115,12 +115,6 @@ def _extract_peak_data(well_plate_data: SeriesData) -> list[dict[str, Any]]:
         if peak_info := _extract_peak_info(well_plate_data, prefix, str(peak_num)):
             peak_data.append(peak_info)
 
-    # Read "peak of interest" / "pkoi" columns to prevent them from leaking
-    # into custom_info, but don't add as a separate peak entry since it
-    # duplicates one of the numbered peaks.
-    poi_prefix = "pkoi" if uses_new_format else "peak of interest"
-    _extract_peak_info(well_plate_data, poi_prefix, "OI")
-
     return peak_data
 
 

--- a/tests/parsers/unchained_labs_lunatic_stunner/testdata/Unchained_Labs_Stunner_example02.json
+++ b/tests/parsers/unchained_labs_lunatic_stunner/testdata/Unchained_Labs_Stunner_example02.json
@@ -644,12 +644,396 @@
                     }
                 },
                 {
+                    "calculated data name": "Peak of Interest Mean Diameter",
+                    "calculated result": {
+                        "value": -0.0,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mean Diameter",
+                    "calculated result": {
+                        "value": 12.5,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mean Diameter",
+                    "calculated result": {
+                        "value": 13.2,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mean Diameter",
+                    "calculated result": {
+                        "value": 14.1,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Est. MW",
+                    "calculated result": {
+                        "value": -0.0,
+                        "unit": "kDa"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Est. MW",
+                    "calculated result": {
+                        "value": 195.0,
+                        "unit": "kDa"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Est. MW",
+                    "calculated result": {
+                        "value": 210.0,
+                        "unit": "kDa"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Est. MW",
+                    "calculated result": {
+                        "value": 225.0,
+                        "unit": "kDa"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Intensity",
+                    "calculated result": {
+                        "value": -0.0,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Intensity",
+                    "calculated result": {
+                        "value": 100.0,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Intensity",
+                    "calculated result": {
+                        "value": 82.5,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Intensity",
+                    "calculated result": {
+                        "value": 65.0,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass",
+                    "calculated result": {
+                        "value": -0.0,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass",
+                    "calculated result": {
+                        "value": 100.0,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass",
+                    "calculated result": {
+                        "value": 98.7,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass",
+                    "calculated result": {
+                        "value": 92.1,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass Mean Diameter",
+                    "calculated result": {
+                        "value": -0.0,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass Mean Diameter",
+                    "calculated result": {
+                        "value": 12.1,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass Mean Diameter",
+                    "calculated result": {
+                        "value": 12.8,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass Mean Diameter",
+                    "calculated result": {
+                        "value": 13.5,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Rayleigh Ratio R",
+                    "calculated result": {
+                        "value": -0.0,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Rayleigh Ratio R",
+                    "calculated result": {
+                        "value": 0.000312,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Rayleigh Ratio R",
+                    "calculated result": {
+                        "value": 0.000289,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Rayleigh Ratio R",
+                    "calculated result": {
+                        "value": 0.000198,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
                     "calculated data name": "Derived intensity (cps)",
                     "calculated result": {
                         "value": -0.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -665,7 +1049,7 @@
                         "value": 8500000.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -681,7 +1065,7 @@
                         "value": 12000000.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -697,7 +1081,7 @@
                         "value": 15000000.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -713,7 +1097,7 @@
                         "value": -0.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -729,7 +1113,7 @@
                         "value": 0.000245,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -745,7 +1129,7 @@
                         "value": 0.000341,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -761,7 +1145,7 @@
                         "value": 0.000425,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -777,7 +1161,7 @@
                         "value": -0.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
                     "calculation description": "y = NaNx + NaN",
                     "data source aggregate document": {
                         "data source document": [
@@ -794,7 +1178,7 @@
                         "value": 0.98,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
                     "calculation description": "y = -0.052x + 11.8",
                     "data source aggregate document": {
                         "data source document": [
@@ -811,7 +1195,7 @@
                         "value": 0.95,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
                     "calculation description": "y = -0.038x + 12.1",
                     "data source aggregate document": {
                         "data source document": [
@@ -828,7 +1212,7 @@
                         "value": -0.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
                     "calculation description": "y = NaNx + NaN",
                     "data source aggregate document": {
                         "data source document": [
@@ -845,7 +1229,7 @@
                         "value": -0.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
                     "calculation description": "y = NaNx + NaN",
                     "data source aggregate document": {
                         "data source document": [
@@ -862,7 +1246,7 @@
                         "value": 0.97,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
                     "calculation description": "y = -1.05e-04x + 11.8",
                     "data source aggregate document": {
                         "data source document": [
@@ -879,7 +1263,7 @@
                         "value": 0.93,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
                     "calculation description": "y = -8.2e-05x + 12.1",
                     "data source aggregate document": {
                         "data source document": [
@@ -896,7 +1280,7 @@
                         "value": -0.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
                     "calculation description": "y = NaNx + NaN",
                     "data source aggregate document": {
                         "data source document": [
@@ -913,7 +1297,7 @@
                         "value": 0.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -929,7 +1313,7 @@
                         "value": 0.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -945,7 +1329,7 @@
                         "value": 0.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -961,7 +1345,7 @@
                         "value": 0.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -977,7 +1361,7 @@
                         "value": 1.002,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -993,7 +1377,7 @@
                         "value": 1.002,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1009,7 +1393,7 @@
                         "value": 1.002,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1025,7 +1409,7 @@
                         "value": 1.002,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1041,7 +1425,7 @@
                         "value": 1.334,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1057,7 +1441,7 @@
                         "value": 1.334,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1073,7 +1457,7 @@
                         "value": 1.334,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1089,7 +1473,7 @@
                         "value": 1.334,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1105,7 +1489,7 @@
                         "value": 1.334,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1121,7 +1505,7 @@
                         "value": 1.334,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1137,7 +1521,7 @@
                         "value": 1.334,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1153,7 +1537,7 @@
                         "value": 1.334,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1169,7 +1553,7 @@
                         "value": -0.0,
                         "unit": "nm"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1185,7 +1569,7 @@
                         "value": 11.8,
                         "unit": "nm"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1201,7 +1585,7 @@
                         "value": 12.1,
                         "unit": "nm"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1217,7 +1601,7 @@
                         "value": -0.0,
                         "unit": "nm"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1233,7 +1617,7 @@
                         "value": -0.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1249,7 +1633,7 @@
                         "value": 1.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1265,7 +1649,7 @@
                         "value": 2.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1281,7 +1665,7 @@
                         "value": 3.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -1297,7 +1681,7 @@
             "ASM file identifier": "Unchained_Labs_Stunner_example02.json",
             "data system instance identifier": "N/A",
             "ASM converter name": "allotropy_unchained_labs_lunatic_&_stunner",
-            "ASM converter version": "0.1.130",
+            "ASM converter version": "0.1.131",
             "UNC path": "tests/parsers/unchained_labs_lunatic_stunner/testdata/Unchained_Labs_Stunner_example02.xlsx",
             "file name": "Unchained_Labs_Stunner_example02.xlsx",
             "software name": "Lunatic and Stunner Analysis",
@@ -1393,6 +1777,30 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Diffusion coefficient"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Peak of Interest Mean Diameter"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Peak of Interest Est. MW"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Peak of Interest Intensity"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Peak of Interest Mass"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Peak of Interest Mass Mean Diameter"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Peak of Interest Rayleigh Ratio R"
                                     },
                                     {
                                         "error": "N/A",

--- a/tests/parsers/unchained_labs_lunatic_stunner/testdata/Unchained_Labs_Stunner_example03.json
+++ b/tests/parsers/unchained_labs_lunatic_stunner/testdata/Unchained_Labs_Stunner_example03.json
@@ -404,12 +404,204 @@
                     }
                 },
                 {
+                    "calculated data name": "Peak of Interest Mean Diameter",
+                    "calculated result": {
+                        "value": 535.8,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mean Diameter",
+                    "calculated result": {
+                        "value": 22.0,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Est. MW",
+                    "calculated result": {
+                        "value": 2130000.0,
+                        "unit": "kDa"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Est. MW",
+                    "calculated result": {
+                        "value": 778.0,
+                        "unit": "kDa"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Intensity",
+                    "calculated result": {
+                        "value": 100.0,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Intensity",
+                    "calculated result": {
+                        "value": 7.0,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass",
+                    "calculated result": {
+                        "value": 100.0,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass",
+                    "calculated result": {
+                        "value": 93.4,
+                        "unit": "%"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass Mean Diameter",
+                    "calculated result": {
+                        "value": 522.8,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Mass Mean Diameter",
+                    "calculated result": {
+                        "value": 20.7,
+                        "unit": "nm"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Rayleigh Ratio R",
+                    "calculated result": {
+                        "value": 0.281,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Peak of Interest Rayleigh Ratio R",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
                     "calculated data name": "Rayleigh ratio R",
                     "calculated result": {
                         "value": 0.258,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -425,7 +617,7 @@
                         "value": 0.281,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -441,199 +633,199 @@
                         "value": 2.3,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Viscosity at T (cP)",
-                    "calculated result": {
-                        "value": 0.759,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Viscosity at T (cP)",
-                    "calculated result": {
-                        "value": 0.759,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Viscosity at T (cP)",
-                    "calculated result": {
-                        "value": 0.759,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Viscosity at 20°C (cP)",
-                    "calculated result": {
-                        "value": 0.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Viscosity at 20°C (cP)",
-                    "calculated result": {
-                        "value": 0.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Viscosity at 20°C (cP)",
-                    "calculated result": {
-                        "value": 0.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "RI at T",
-                    "calculated result": {
-                        "value": 1.334,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "RI at T",
-                    "calculated result": {
-                        "value": 1.334,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "RI at T",
-                    "calculated result": {
-                        "value": 1.334,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "RI at 20°C",
-                    "calculated result": {
-                        "value": 1.334,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "RI at 20°C",
-                    "calculated result": {
-                        "value": 1.334,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                                "data source feature": "dynamic light scattering"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "RI at 20°C",
-                    "calculated result": {
-                        "value": 1.334,
-                        "unit": "(unitless)"
-                    },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Viscosity at T (cP)",
+                    "calculated result": {
+                        "value": 0.759,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Viscosity at T (cP)",
+                    "calculated result": {
+                        "value": 0.759,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Viscosity at T (cP)",
+                    "calculated result": {
+                        "value": 0.759,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Viscosity at 20°C (cP)",
+                    "calculated result": {
+                        "value": 0.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Viscosity at 20°C (cP)",
+                    "calculated result": {
+                        "value": 0.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Viscosity at 20°C (cP)",
+                    "calculated result": {
+                        "value": 0.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "RI at T",
+                    "calculated result": {
+                        "value": 1.334,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "RI at T",
+                    "calculated result": {
+                        "value": 1.334,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "RI at T",
+                    "calculated result": {
+                        "value": 1.334,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "RI at 20°C",
+                    "calculated result": {
+                        "value": 1.334,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "RI at 20°C",
+                    "calculated result": {
+                        "value": 1.334,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "dynamic light scattering"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "RI at 20°C",
+                    "calculated result": {
+                        "value": 1.334,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -649,7 +841,7 @@
                         "value": 0.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -665,7 +857,7 @@
                         "value": 1.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -681,7 +873,7 @@
                         "value": 2.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -697,7 +889,7 @@
                         "value": 1.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -713,7 +905,7 @@
                         "value": 1.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -729,7 +921,7 @@
                         "value": 1.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -745,7 +937,7 @@
                         "value": 142.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -761,7 +953,7 @@
                         "value": 142.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -777,7 +969,7 @@
                         "value": 142.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -793,7 +985,7 @@
                         "value": 0.025,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -809,7 +1001,7 @@
                         "value": 0.068,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -825,7 +1017,7 @@
                         "value": 0.798,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -841,7 +1033,7 @@
             "ASM file identifier": "Unchained_Labs_Stunner_example03.json",
             "data system instance identifier": "N/A",
             "ASM converter name": "allotropy_unchained_labs_lunatic_&_stunner",
-            "ASM converter version": "0.1.130",
+            "ASM converter version": "0.1.131",
             "UNC path": "tests/parsers/unchained_labs_lunatic_stunner/testdata/Unchained_Labs_Stunner_example03.xlsx",
             "file name": "Unchained_Labs_Stunner_example03.xlsx",
             "software name": "Lunatic and Stunner Analysis"


### PR DESCRIPTION
## Summary
- PkOI (Peak of Interest) columns were being silently discarded — consumed by peak extraction to prevent custom info leaking, but never written to output
- Added `alt_columns` for new `pkoi` naming convention to existing `CALCULATED_DATA_LOOKUP` Peak of Interest entries
- Added two new calculated data entries: Peak of Interest Mass Mean Diameter and Peak of Interest Rayleigh Ratio R (new fields in newer instrument software)
- All 72 columns from the customer file are now accounted for in the ASM output

## Context
Follow-up to #1213. The `CALCULATED_DATA_LOOKUP` already had "Peak of Interest" entries but they used old column names (`peak of interest mean dia (nm)`) that didn't match the new format (`pkoi intensity mean dia. (nm)`). Meanwhile, `_extract_peak_data` was consuming the PkOI columns to prevent leaking, effectively discarding the data entirely.

## Test plan
- [x] All 34 Stunner/Lunatic tests pass
- [x] Lint clean (ruff, black, mypy)
- [x] Customer file produces 510 Peak of Interest calculated data docs across 6 fields
- [x] All 72 original columns validated as present in ASM output
- [x] 60/85 measurements have real PkOI values, 25 correctly report N/A (blanks/no-peaks)
- [x] No duplicate columns in data system document

🤖 Generated with [Claude Code](https://claude.com/claude-code)