### PR TITLE
fix: Make schema registry building fully deterministic

### DIFF
--- a/src/allotropy/allotrope/schemas.py
+++ b/src/allotropy/allotrope/schemas.py
@@ -273,6 +273,9 @@ def _get_registry() -> Registry[dict[str, Any]]:
     under $defs with their own $id. When a bundled copy is LARGER than the standalone
     (more enum values, more definitions), we use the bundled version so that extended
     schemas take precedence. When a bundled copy is a subset, we keep the standalone.
+
+    Resolution is fully deterministic: files are sorted, the largest version of each $id
+    wins, and on size ties standalone schemas take precedence over bundled copies.
     """
     global _registry  # noqa: PLW0603
     if _registry is not None:
@@ -280,25 +283,33 @@ def _get_registry() -> Registry[dict[str, Any]]:
 
     schemas_by_id: dict[str, dict[str, Any]] = {}
     sizes_by_id: dict[str, int] = {}
+    is_standalone: dict[str, bool] = {}
 
-    for schema_file in SCHEMA_DIR_PATH.rglob("*.schema.json"):
+    for schema_file in sorted(SCHEMA_DIR_PATH.rglob("*.schema.json")):
         with open(schema_file, encoding=DEFAULT_ENCODING) as f:
             schema = json.load(f)
         schema_id = schema.get("$id")
         if not schema_id:
             continue
-        if schema_id not in schemas_by_id:
+        schema_size = _schema_content_size(schema)
+        existing_size = sizes_by_id.get(schema_id, -1)
+        if schema_size > existing_size or (
+            schema_size == existing_size and not is_standalone.get(schema_id, False)
+        ):
             schemas_by_id[schema_id] = schema
-            sizes_by_id[schema_id] = _schema_content_size(schema)
+            sizes_by_id[schema_id] = schema_size
+            is_standalone[schema_id] = True
 
         for val in schema.get("$defs", {}).values():
             if not isinstance(val, dict) or "$id" not in val:
                 continue
             bundled_id = val["$id"]
             bundled_size = _schema_content_size(val)
-            if bundled_size > sizes_by_id.get(bundled_id, -1):
+            existing_size = sizes_by_id.get(bundled_id, -1)
+            if bundled_size > existing_size:
                 schemas_by_id[bundled_id] = val
                 sizes_by_id[bundled_id] = bundled_size
+                is_standalone[bundled_id] = False
 
     _registry = Registry().with_resources(
         (


### PR DESCRIPTION
## Summary

- Fixes non-deterministic schema resolution in `_get_registry()` that caused `nM` unit validation failures on some platforms (Linux CI) but not others (macOS)
- `Path.rglob()` returns files in OS/filesystem-dependent order. When the flow-cytometry bundled units schema (771 defs, missing `nM`) was processed before the standalone (773 defs, has `nM`), the old first-wins logic for standalone registration prevented the correct schema from being used
- Sorts `rglob` results for consistent iteration order across all platforms
- Applies size comparison uniformly to both standalone and bundled schemas, with standalone winning on ties (21 tie cases exist across the schema set)
- Verified fully deterministic: forward vs reverse iteration produces byte-identical registry contents

## Root Cause

The standalone registration path used `if schema_id not in schemas_by_id` (first-wins, no size check), while the bundled path used `if bundled_size > sizes_by_id.get(...)` (largest-wins). When a bundled subset was encountered first, the standalone could never override it.

## Test plan

- [x] All 734 parser tests pass
- [x] All 379 discover_vendor + schema tests pass
- [x] Determinism proven: building registry with sorted-forward vs sorted-reverse file lists produces identical results for all 105 schema `$id`s
- [x] `nM` resolves correctly regardless of iteration order
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)