### PR TITLE
fix: Make space optional in Cytiva UNICORN UV curve regexes

### DIFF
--- a/src/allotropy/parsers/cytiva_unicorn/structure/measurements/absorbance.py
+++ b/src/allotropy/parsers/cytiva_unicorn/structure/measurements/absorbance.py
@@ -92,7 +92,7 @@ class AbsorbanceMeasurement(UnicornMeasurement):
 class AbsorbanceMeasurement1(AbsorbanceMeasurement):
     @classmethod
     def get_curve_regex(cls) -> str:
-        return r"^UV( 1_\d+)?$"
+        return r"^UV( ?1_\d+)?$"
 
     @classmethod
     def get_peaks_custom_info(
@@ -191,10 +191,10 @@ class AbsorbanceMeasurement1(AbsorbanceMeasurement):
 class AbsorbanceMeasurement2(AbsorbanceMeasurement):
     @classmethod
     def get_curve_regex(cls) -> str:
-        return r"^UV 2_\d+$"
+        return r"^UV ?2_\d+$"
 
 
 class AbsorbanceMeasurement3(AbsorbanceMeasurement):
     @classmethod
     def get_curve_regex(cls) -> str:
-        return r"^UV 3_\d+$"
+        return r"^UV ?3_\d+$"


### PR DESCRIPTION
## Summary

- Makes the space between "UV" and the digit optional in all three absorbance measurement regexes (`UV 1_`, `UV 2_`, `UV 3_` → `UV ?1_`, `UV ?2_`, `UV ?3_`)
- Fixes silent loss of UV absorbance measurements for exports that use the no-space format (e.g. AKTApilot devices)

## Context

Some UNICORN exports declare UV curves as `UV1_280` / `UV2_0` / `UV3_0` (no space), while others use `UV 1_280` (with space). The previous regexes required the space, causing `filter_curve_or_none()` to return `None` and silently skip all absorbance measurements.

Reproduced on an AKTApilot 02 export (batch BRR-92117):
- Before fix: 2 measurements (Cond, pH only)
- After fix: 5 measurements (UV1_280, UV2_0, UV3_0, Cond, pH)

## Test plan

- [x] Existing cytiva_unicorn golden tests pass (2/2)
- [x] Verified BRR-92117 file now produces all 5 expected measurements

🤖 Generated with [Claude Code](https://claude.com/claude-code)