### PR TITLE
fix: Handle special characters in Machine ID in Mabtech APEX parser

### DIFF
--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_structure.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_structure.py
@@ -22,14 +22,14 @@ from allotropy.parsers.utils.uuids import random_uuid_str
 
 def create_metadata(plate_info: SeriesData, file_path: str) -> Metadata:
     raw_machine_id = plate_info[str, "Machine ID"]
-    machine_id_match = re.match(r"([A-Z]+[a-z]*) ([0-9]+)", raw_machine_id)
+    machine_id_match = re.match(r"([A-Za-z]+)\W*(\d+)", raw_machine_id)
 
     if machine_id_match:
         model_number = machine_id_match.group(1)
         serial_number = machine_id_match.group(2)
-    elif re.fullmatch(r"[0-9]+", raw_machine_id):
+    elif re.search(r"\d+", raw_machine_id):
         model_number = NOT_APPLICABLE
-        serial_number = raw_machine_id
+        serial_number = re.search(r"\d+", raw_machine_id).group()  # type: ignore[union-attr]
     else:
         msg = f"Unable to interpret Machine ID: {raw_machine_id}"
         raise AllotropeConversionError(msg)


### PR DESCRIPTION
## Summary
- Some APEX instruments include special characters like `#` in the Machine ID field (e.g. `"IRIS #569"`, `"#569"`)
- The previous regex only handled `"Model 1234"` and bare numeric formats, causing `AllotropeConversionError` on these files
- Generalized the regex to use `\W*` (any non-word characters) between model and serial number, and extract digits from any format in the fallback case

## Test plan
- [x] Verified both failing files (`Mabtech_IRIS569.xlsx`, `Mabtech_IRISIRIS_569 (1).xlsx`) now parse successfully
- [x] Existing mabtech_apex tests still pass (4/4)
- [x] Lint passes (ruff, black, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)