### PR TITLE
fix: Surface previously skipped columns as custom info in NovaBio Flex2 parser

### DIFF
--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
@@ -89,10 +89,6 @@ class Sample:
             cell_density_dilution = cell_density_dilution.split(":")[0]
 
         unused_keys = {
-            "Sample Time",
-            "PCO2 @ Temp",
-            "PO2 @ Temp",
-            "pH @ Temp",
             "Operator",
             "Osm",
         }

--- a/tests/parsers/novabio_flex2/testdata/SampleResults2022-06-28_142558.json
+++ b/tests/parsers/novabio_flex2/testdata/SampleResults2022-06-28_142558.json
@@ -1,6 +1,19 @@
 {
     "$asm.manifest": "http://purl.allotrope.org/manifests/solution-analyzer/BENCHLING/2024/09/solution-analyzer.manifest",
     "solution analyzer aggregate document": {
+        "data system document": {
+            "ASM file identifier": "SampleResults2022-06-28_142558.json",
+            "data system instance identifier": "N/A",
+            "ASM converter name": "allotropy_novabio_flex2",
+            "ASM converter version": "0.1.138",
+            "file name": "SampleResults2022-06-28_142558.csv",
+            "software name": "NovaBio Flex",
+            "UNC path": "tests/parsers/novabio_flex2/testdata/SampleResults2022-06-28_142558.csv"
+        },
+        "device system document": {
+            "model number": "Flex2",
+            "product manufacturer": "Nova Biomedical"
+        },
         "solution analyzer document": [
             {
                 "measurement aggregate document": {
@@ -9,13 +22,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "metabolite-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Sparging O2%": 20.9,
                                             "Chemistry Flow Time": 6.67,
-                                            "pH / Gas Flow Time": 3.65
+                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.65,
+                                            "Sparging O2%": 20.9
                                         }
                                     }
                                 ]
@@ -27,9 +40,13 @@
                                 "batch identifier": "BATCH_123",
                                 "description": "Spent Media",
                                 "custom information document": {
-                                    "Vessel ID": "3L Bioreactor",
+                                    "Cell Type": "Workhog",
+                                    "Sample Time": "24-6-2022  14:34:52",
+                                    "pH @ Temp": 7.4,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Cell Type": "Workhog"
+                                    "Vessel ID": "3L Bioreactor",
+                                    "PCO2 @ Temp": 46.8,
+                                    "PO2 @ Temp": 191.6
                                 }
                             },
                             "analyte aggregate document": {
@@ -104,13 +121,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "blood-gas-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Sparging O2%": 20.9,
                                             "Chemistry Flow Time": 6.67,
-                                            "pH / Gas Flow Time": 3.65
+                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.65,
+                                            "Sparging O2%": 20.9
                                         }
                                     }
                                 ]
@@ -122,9 +139,13 @@
                                 "batch identifier": "BATCH_123",
                                 "description": "Spent Media",
                                 "custom information document": {
-                                    "Vessel ID": "3L Bioreactor",
+                                    "Cell Type": "Workhog",
+                                    "Sample Time": "24-6-2022  14:34:52",
+                                    "pH @ Temp": 7.4,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Cell Type": "Workhog"
+                                    "Vessel ID": "3L Bioreactor",
+                                    "PCO2 @ Temp": 46.8,
+                                    "PO2 @ Temp": 191.6
                                 }
                             },
                             "pO2": {
@@ -148,13 +169,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "ph-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Sparging O2%": 20.9,
                                             "Chemistry Flow Time": 6.67,
-                                            "pH / Gas Flow Time": 3.65
+                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.65,
+                                            "Sparging O2%": 20.9
                                         }
                                     }
                                 ]
@@ -166,9 +187,13 @@
                                 "batch identifier": "BATCH_123",
                                 "description": "Spent Media",
                                 "custom information document": {
-                                    "Vessel ID": "3L Bioreactor",
+                                    "Cell Type": "Workhog",
+                                    "Sample Time": "24-6-2022  14:34:52",
+                                    "pH @ Temp": 7.4,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Cell Type": "Workhog"
+                                    "Vessel ID": "3L Bioreactor",
+                                    "PCO2 @ Temp": 46.8,
+                                    "PO2 @ Temp": 191.6
                                 }
                             },
                             "pH": {
@@ -185,19 +210,6 @@
                 },
                 "analyst": "ANALYST1"
             }
-        ],
-        "data system document": {
-            "ASM file identifier": "SampleResults2022-06-28_142558.json",
-            "data system instance identifier": "N/A",
-            "file name": "SampleResults2022-06-28_142558.csv",
-            "UNC path": "tests/parsers/novabio_flex2/testdata/SampleResults2022-06-28_142558.csv",
-            "ASM converter name": "allotropy_novabio_flex2",
-            "ASM converter version": "0.1.105",
-            "software name": "NovaBio Flex"
-        },
-        "device system document": {
-            "model number": "Flex2",
-            "product manufacturer": "Nova Biomedical"
-        }
+        ]
     }
 }

--- a/tests/parsers/novabio_flex2/testdata/SampleResultsDEVICE1232021-02-18_104838.json
+++ b/tests/parsers/novabio_flex2/testdata/SampleResultsDEVICE1232021-02-18_104838.json
@@ -1,6 +1,20 @@
 {
     "$asm.manifest": "http://purl.allotrope.org/manifests/solution-analyzer/BENCHLING/2024/09/solution-analyzer.manifest",
     "solution analyzer aggregate document": {
+        "data system document": {
+            "ASM file identifier": "SampleResultsDEVICE1232021-02-18_104838.json",
+            "data system instance identifier": "N/A",
+            "ASM converter name": "allotropy_novabio_flex2",
+            "ASM converter version": "0.1.138",
+            "file name": "SampleResultsDEVICE1232021-02-18_104838.csv",
+            "software name": "NovaBio Flex",
+            "UNC path": "tests/parsers/novabio_flex2/testdata/SampleResultsDEVICE1232021-02-18_104838.csv"
+        },
+        "device system document": {
+            "device identifier": "DEVICE123",
+            "model number": "Flex2",
+            "product manufacturer": "Nova Biomedical"
+        },
         "solution analyzer document": [
             {
                 "measurement aggregate document": {
@@ -9,15 +23,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "metabolite-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.5,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.51,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 3.94,
+                                            "Cell Density Flow": 5.51,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.94
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -28,9 +42,13 @@
                                 "sample identifier": "SAMPLE 0001",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:28:04 AM",
+                                    "pH @ Temp": 7.34,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 10.3,
+                                    "PO2 @ Temp": 197.1
                                 }
                             },
                             "analyte aggregate document": {
@@ -105,15 +123,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "cell-counting",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.5,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.51,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 3.94,
+                                            "Cell Density Flow": 5.51,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.94
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -124,30 +142,34 @@
                                 "sample identifier": "SAMPLE 0001",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:28:04 AM",
+                                    "pH @ Temp": 7.34,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 10.3,
+                                    "PO2 @ Temp": 197.1
                                 }
                             },
                             "processed data aggregate document": {
                                 "processed data document": [
                                     {
-                                        "viability (cell counter)": {
-                                            "value": 0.0,
-                                            "unit": "%"
-                                        },
-                                        "viable cell density (cell counter)": {
-                                            "value": 0.0,
-                                            "unit": "10^6 cells/mL"
-                                        },
                                         "data processing document": {
                                             "cell density dilution factor": {
                                                 "value": 1.0,
                                                 "unit": "(unitless)"
                                             }
                                         },
+                                        "viability (cell counter)": {
+                                            "value": 0.0,
+                                            "unit": "%"
+                                        },
                                         "total cell density (cell counter)": {
                                             "value": 0.17,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "viable cell density (cell counter)": {
+                                            "value": 0.0,
                                             "unit": "10^6 cells/mL"
                                         },
                                         "total cell count": {
@@ -166,15 +188,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "blood-gas-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.5,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.51,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 3.94,
+                                            "Cell Density Flow": 5.51,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.94
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -185,9 +207,13 @@
                                 "sample identifier": "SAMPLE 0001",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:28:04 AM",
+                                    "pH @ Temp": 7.34,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 10.3,
+                                    "PO2 @ Temp": 197.1
                                 }
                             },
                             "pO2": {
@@ -211,15 +237,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "osmolality-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.5,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.51,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 3.94,
+                                            "Cell Density Flow": 5.51,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.94
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -230,9 +256,13 @@
                                 "sample identifier": "SAMPLE 0001",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:28:04 AM",
+                                    "pH @ Temp": 7.34,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 10.3,
+                                    "PO2 @ Temp": 197.1
                                 }
                             },
                             "osmolality": {
@@ -244,15 +274,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "ph-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.5,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.51,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 3.94,
+                                            "Cell Density Flow": 5.51,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.94
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -263,9 +293,13 @@
                                 "sample identifier": "SAMPLE 0001",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:28:04 AM",
+                                    "pH @ Temp": 7.34,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 10.3,
+                                    "PO2 @ Temp": 197.1
                                 }
                             },
                             "pH": {
@@ -289,15 +323,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "metabolite-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.57,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.4,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 4.0,
+                                            "Cell Density Flow": 5.4,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 4.0
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -308,9 +342,13 @@
                                 "sample identifier": "SAMPLE 0002",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:33:17 AM",
+                                    "pH @ Temp": 7.262,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 14.5,
+                                    "PO2 @ Temp": 211.9
                                 }
                             },
                             "analyte aggregate document": {
@@ -385,15 +423,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "cell-counting",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.57,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.4,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 4.0,
+                                            "Cell Density Flow": 5.4,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 4.0
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -404,30 +442,34 @@
                                 "sample identifier": "SAMPLE 0002",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:33:17 AM",
+                                    "pH @ Temp": 7.262,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 14.5,
+                                    "PO2 @ Temp": 211.9
                                 }
                             },
                             "processed data aggregate document": {
                                 "processed data document": [
                                     {
-                                        "viability (cell counter)": {
-                                            "value": 0.0,
-                                            "unit": "%"
-                                        },
-                                        "viable cell density (cell counter)": {
-                                            "value": 10.0,
-                                            "unit": "10^6 cells/mL"
-                                        },
                                         "data processing document": {
                                             "cell density dilution factor": {
                                                 "value": 1.0,
                                                 "unit": "(unitless)"
                                             }
                                         },
+                                        "viability (cell counter)": {
+                                            "value": 0.0,
+                                            "unit": "%"
+                                        },
                                         "total cell density (cell counter)": {
                                             "value": 0.18,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "viable cell density (cell counter)": {
+                                            "value": 10.0,
                                             "unit": "10^6 cells/mL"
                                         },
                                         "total cell count": {
@@ -446,15 +488,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "blood-gas-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.57,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.4,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 4.0,
+                                            "Cell Density Flow": 5.4,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 4.0
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -465,9 +507,13 @@
                                 "sample identifier": "SAMPLE 0002",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:33:17 AM",
+                                    "pH @ Temp": 7.262,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 14.5,
+                                    "PO2 @ Temp": 211.9
                                 }
                             },
                             "pO2": {
@@ -491,15 +537,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "osmolality-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.57,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.4,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 4.0,
+                                            "Cell Density Flow": 5.4,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 4.0
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -510,9 +556,13 @@
                                 "sample identifier": "SAMPLE 0002",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:33:17 AM",
+                                    "pH @ Temp": 7.262,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 14.5,
+                                    "PO2 @ Temp": 211.9
                                 }
                             },
                             "osmolality": {
@@ -524,15 +574,15 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "ph-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.57,
-                                            "Vessel Pressure (psi)": 0.0,
-                                            "Cell Density Flow": 5.4,
                                             "Valid Images": 47.0,
+                                            "pH / Gas Flow Time": 4.0,
+                                            "Cell Density Flow": 5.4,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 4.0
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -543,9 +593,13 @@
                                 "sample identifier": "SAMPLE 0002",
                                 "description": "Default",
                                 "custom information document": {
-                                    "Chemistry Dilution Ratio": "1:1",
                                     "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "Sample Time": "2/18/2021  10:33:17 AM",
+                                    "pH @ Temp": 7.262,
+                                    "Pre-Dilution Multiplier": 1.0,
+                                    "Chemistry Dilution Ratio": "1:1",
+                                    "PCO2 @ Temp": 14.5,
+                                    "PO2 @ Temp": 211.9
                                 }
                             },
                             "pH": {
@@ -569,13 +623,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "metabolite-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.78,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.88,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.88
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -586,8 +640,12 @@
                                 "sample identifier": "SAMPLE 0003",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:38:33 AM",
+                                    "pH @ Temp": 7.288,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 13.8,
+                                    "PO2 @ Temp": 182.0
                                 }
                             },
                             "analyte aggregate document": {
@@ -662,13 +720,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "blood-gas-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.78,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.88,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.88
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -679,8 +737,12 @@
                                 "sample identifier": "SAMPLE 0003",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:38:33 AM",
+                                    "pH @ Temp": 7.288,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 13.8,
+                                    "PO2 @ Temp": 182.0
                                 }
                             },
                             "pO2": {
@@ -704,13 +766,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "ph-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.78,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.88,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.88
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -721,8 +783,12 @@
                                 "sample identifier": "SAMPLE 0003",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:38:33 AM",
+                                    "pH @ Temp": 7.288,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 13.8,
+                                    "PO2 @ Temp": 182.0
                                 }
                             },
                             "pH": {
@@ -746,13 +812,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "metabolite-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.72,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.83,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.83
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -763,8 +829,12 @@
                                 "sample identifier": "SAMPLE 0004",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:41:08 AM",
+                                    "pH @ Temp": 7.215,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 17.9,
+                                    "PO2 @ Temp": 154.6
                                 }
                             },
                             "analyte aggregate document": {
@@ -839,13 +909,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "blood-gas-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.72,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.83,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.83
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -856,8 +926,12 @@
                                 "sample identifier": "SAMPLE 0004",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:41:08 AM",
+                                    "pH @ Temp": 7.215,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 17.9,
+                                    "PO2 @ Temp": 154.6
                                 }
                             },
                             "pO2": {
@@ -881,13 +955,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "ph-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.72,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.83,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.83
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -898,8 +972,12 @@
                                 "sample identifier": "SAMPLE 0004",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:41:08 AM",
+                                    "pH @ Temp": 7.215,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 17.9,
+                                    "PO2 @ Temp": 154.6
                                 }
                             },
                             "pH": {
@@ -923,13 +1001,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "metabolite-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.5,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.88,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.88
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -940,8 +1018,12 @@
                                 "sample identifier": "SAMPLE 0005",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:43:33 AM",
+                                    "pH @ Temp": 7.252,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 15.1,
+                                    "PO2 @ Temp": 158.3
                                 }
                             },
                             "analyte aggregate document": {
@@ -1016,13 +1098,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "blood-gas-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.5,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.88,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.88
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -1033,8 +1115,12 @@
                                 "sample identifier": "SAMPLE 0005",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:43:33 AM",
+                                    "pH @ Temp": 7.252,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 15.1,
+                                    "PO2 @ Temp": 158.3
                                 }
                             },
                             "pO2": {
@@ -1058,13 +1144,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "ph-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.5,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 3.88,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 3.88
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -1075,8 +1161,12 @@
                                 "sample identifier": "SAMPLE 0005",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:43:33 AM",
+                                    "pH @ Temp": 7.252,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 15.1,
+                                    "PO2 @ Temp": 158.3
                                 }
                             },
                             "pH": {
@@ -1100,13 +1190,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "metabolite-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.73,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 4.02,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 4.02
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -1117,8 +1207,12 @@
                                 "sample identifier": "SAMPLE 0006",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:46:05 AM",
+                                    "pH @ Temp": 7.278,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 10.1,
+                                    "PO2 @ Temp": 176.2
                                 }
                             },
                             "analyte aggregate document": {
@@ -1193,13 +1287,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "blood-gas-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.73,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 4.02,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 4.02
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -1210,8 +1304,12 @@
                                 "sample identifier": "SAMPLE 0006",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:46:05 AM",
+                                    "pH @ Temp": 7.278,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 10.1,
+                                    "PO2 @ Temp": 176.2
                                 }
                             },
                             "pO2": {
@@ -1235,13 +1333,13 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "ph-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
                                             "Chemistry Flow Time": 7.73,
-                                            "Vessel Pressure (psi)": 0.0,
+                                            "pH / Gas Flow Time": 4.02,
                                             "Sparging O2%": 20.9,
-                                            "pH / Gas Flow Time": 4.02
+                                            "Vessel Pressure (psi)": 0.0
                                         }
                                     }
                                 ]
@@ -1252,8 +1350,12 @@
                                 "sample identifier": "SAMPLE 0006",
                                 "description": "Simple",
                                 "custom information document": {
+                                    "Sample Time": "2/18/2021  10:46:05 AM",
+                                    "pH @ Temp": 7.278,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:1",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": 10.1,
+                                    "PO2 @ Temp": 176.2
                                 }
                             },
                             "pH": {
@@ -1270,20 +1372,6 @@
                 },
                 "analyst": "Unither"
             }
-        ],
-        "data system document": {
-            "ASM file identifier": "SampleResultsDEVICE1232021-02-18_104838.json",
-            "data system instance identifier": "N/A",
-            "file name": "SampleResultsDEVICE1232021-02-18_104838.csv",
-            "UNC path": "tests/parsers/novabio_flex2/testdata/SampleResultsDEVICE1232021-02-18_104838.csv",
-            "ASM converter name": "allotropy_novabio_flex2",
-            "ASM converter version": "0.1.105",
-            "software name": "NovaBio Flex"
-        },
-        "device system document": {
-            "device identifier": "DEVICE123",
-            "model number": "Flex2",
-            "product manufacturer": "Nova Biomedical"
-        }
+        ]
     }
 }

--- a/tests/parsers/novabio_flex2/testdata/SampleResultsT123456789C2020-01-01_162647.json
+++ b/tests/parsers/novabio_flex2/testdata/SampleResultsT123456789C2020-01-01_162647.json
@@ -1,6 +1,20 @@
 {
     "$asm.manifest": "http://purl.allotrope.org/manifests/solution-analyzer/BENCHLING/2024/09/solution-analyzer.manifest",
     "solution analyzer aggregate document": {
+        "data system document": {
+            "ASM file identifier": "SampleResultsT123456789C2020-01-01_162647.json",
+            "data system instance identifier": "N/A",
+            "ASM converter name": "allotropy_novabio_flex2",
+            "ASM converter version": "0.1.138",
+            "file name": "SampleResultsT123456789C2020-01-01_162647.csv",
+            "software name": "NovaBio Flex",
+            "UNC path": "tests/parsers/novabio_flex2/testdata/SampleResultsT123456789C2020-01-01_162647.csv"
+        },
+        "device system document": {
+            "device identifier": "T123456789C",
+            "model number": "Flex2",
+            "product manufacturer": "Nova Biomedical"
+        },
         "solution analyzer document": [
             {
                 "measurement aggregate document": {
@@ -9,12 +23,12 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "metabolite-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
-                                            "Sparging O2%": 1.0,
-                                            "pH / Gas Flow Time": 1.0,
                                             "Chemistry Flow Time": 1.0,
+                                            "pH / Gas Flow Time": 1.0,
+                                            "Sparging O2%": 1.0,
                                             "Vessel Pressure (psi)": 1.0
                                         }
                                     }
@@ -27,10 +41,14 @@
                                 "batch identifier": "1.0",
                                 "description": "Default",
                                 "custom information document": {
+                                    "Cell Inspection Type": "StandardCHO",
+                                    "Sample Time": "1/1/2020 16:20",
+                                    "pH @ Temp": 1.0,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:01",
                                     "Vessel ID": 1.0,
-                                    "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": "mmHg",
+                                    "PO2 @ Temp": "mmHg"
                                 }
                             },
                             "analyte aggregate document": {
@@ -105,12 +123,12 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "cell-counting",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
-                                            "Sparging O2%": 1.0,
-                                            "pH / Gas Flow Time": 1.0,
                                             "Chemistry Flow Time": 1.0,
+                                            "pH / Gas Flow Time": 1.0,
+                                            "Sparging O2%": 1.0,
                                             "Vessel Pressure (psi)": 1.0
                                         }
                                     }
@@ -123,23 +141,19 @@
                                 "batch identifier": "1.0",
                                 "description": "Default",
                                 "custom information document": {
+                                    "Cell Inspection Type": "StandardCHO",
+                                    "Sample Time": "1/1/2020 16:20",
+                                    "pH @ Temp": 1.0,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:01",
                                     "Vessel ID": 1.0,
-                                    "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": "mmHg",
+                                    "PO2 @ Temp": "mmHg"
                                 }
                             },
                             "processed data aggregate document": {
                                 "processed data document": [
                                     {
-                                        "viability (cell counter)": {
-                                            "value": 1.0,
-                                            "unit": "%"
-                                        },
-                                        "viable cell density (cell counter)": {
-                                            "value": 1.0,
-                                            "unit": "10^6 cells/mL"
-                                        },
                                         "data processing document": {
                                             "cell type processing method": "1.0",
                                             "cell density dilution factor": {
@@ -147,7 +161,15 @@
                                                 "unit": "(unitless)"
                                             }
                                         },
+                                        "viability (cell counter)": {
+                                            "value": 1.0,
+                                            "unit": "%"
+                                        },
                                         "total cell density (cell counter)": {
+                                            "value": 1.0,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "viable cell density (cell counter)": {
                                             "value": 1.0,
                                             "unit": "10^6 cells/mL"
                                         }
@@ -159,12 +181,12 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "blood-gas-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
-                                            "Sparging O2%": 1.0,
-                                            "pH / Gas Flow Time": 1.0,
                                             "Chemistry Flow Time": 1.0,
+                                            "pH / Gas Flow Time": 1.0,
+                                            "Sparging O2%": 1.0,
                                             "Vessel Pressure (psi)": 1.0
                                         }
                                     }
@@ -177,10 +199,14 @@
                                 "batch identifier": "1.0",
                                 "description": "Default",
                                 "custom information document": {
+                                    "Cell Inspection Type": "StandardCHO",
+                                    "Sample Time": "1/1/2020 16:20",
+                                    "pH @ Temp": 1.0,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:01",
                                     "Vessel ID": 1.0,
-                                    "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": "mmHg",
+                                    "PO2 @ Temp": "mmHg"
                                 }
                             },
                             "pO2": {
@@ -204,12 +230,12 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "osmolality-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
-                                            "Sparging O2%": 1.0,
-                                            "pH / Gas Flow Time": 1.0,
                                             "Chemistry Flow Time": 1.0,
+                                            "pH / Gas Flow Time": 1.0,
+                                            "Sparging O2%": 1.0,
                                             "Vessel Pressure (psi)": 1.0
                                         }
                                     }
@@ -222,10 +248,14 @@
                                 "batch identifier": "1.0",
                                 "description": "Default",
                                 "custom information document": {
+                                    "Cell Inspection Type": "StandardCHO",
+                                    "Sample Time": "1/1/2020 16:20",
+                                    "pH @ Temp": 1.0,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:01",
                                     "Vessel ID": 1.0,
-                                    "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": "mmHg",
+                                    "PO2 @ Temp": "mmHg"
                                 }
                             },
                             "osmolality": {
@@ -237,12 +267,12 @@
                             "device control aggregate document": {
                                 "device control document": [
                                     {
-                                        "device type": "solution-analyzer",
                                         "detection type": "ph-detection",
+                                        "device type": "solution-analyzer",
                                         "custom information document": {
-                                            "Sparging O2%": 1.0,
-                                            "pH / Gas Flow Time": 1.0,
                                             "Chemistry Flow Time": 1.0,
+                                            "pH / Gas Flow Time": 1.0,
+                                            "Sparging O2%": 1.0,
                                             "Vessel Pressure (psi)": 1.0
                                         }
                                     }
@@ -255,10 +285,14 @@
                                 "batch identifier": "1.0",
                                 "description": "Default",
                                 "custom information document": {
+                                    "Cell Inspection Type": "StandardCHO",
+                                    "Sample Time": "1/1/2020 16:20",
+                                    "pH @ Temp": 1.0,
+                                    "Pre-Dilution Multiplier": 1.0,
                                     "Chemistry Dilution Ratio": "1:01",
                                     "Vessel ID": 1.0,
-                                    "Cell Inspection Type": "StandardCHO",
-                                    "Pre-Dilution Multiplier": 1.0
+                                    "PCO2 @ Temp": "mmHg",
+                                    "PO2 @ Temp": "mmHg"
                                 }
                             },
                             "pH": {
@@ -275,20 +309,6 @@
                 },
                 "analyst": "user"
             }
-        ],
-        "data system document": {
-            "ASM file identifier": "SampleResultsT123456789C2020-01-01_162647.json",
-            "data system instance identifier": "N/A",
-            "file name": "SampleResultsT123456789C2020-01-01_162647.csv",
-            "UNC path": "tests/parsers/novabio_flex2/testdata/SampleResultsT123456789C2020-01-01_162647.csv",
-            "ASM converter name": "allotropy_novabio_flex2",
-            "ASM converter version": "0.1.105",
-            "software name": "NovaBio Flex"
-        },
-        "device system document": {
-            "device identifier": "T123456789C",
-            "model number": "Flex2",
-            "product manufacturer": "Nova Biomedical"
-        }
+        ]
     }
 }


### PR DESCRIPTION
## Summary
- `Sample Time`, `PCO2 @ Temp`, `PO2 @ Temp`, and `pH @ Temp` were incorrectly marked as `unused_keys` in the NovaBio Flex2 parser (introduced in #1070)
- These fields are not duplicates of already-mapped ASM fields — they were skipped by mistake during the PR review categorization
- Removed them from `unused_keys` so they now flow through to `custom_info` in the output
- `Operator` and `Osm` remain suppressed since they are consumed elsewhere (as `analyst` and `osmolality` respectively)

## Test plan
- [x] All 13 NovaBio Flex2 tests pass
- [x] discover_vendor tests pass
- [x] Lint clean (ruff, black, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)