### PR TITLE
fix: Support HIAC Run Counter format in .xlsx files for Beckman PharmSpec parser

### DIFF
--- a/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_reader.py
+++ b/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_reader.py
@@ -21,6 +21,13 @@ class BeckmanPharmspecReader:
     def _read_xlsx(self, named_file_contents: NamedFileContents) -> None:
         df = read_excel(named_file_contents.contents, header=None, engine="calamine")
 
+        # Detect format: PharmSpec uses col1=":" with value in col2,
+        # HIAC Run Counter uses col1=": value" (colon+value merged).
+        is_pharmspec = df[1].str.strip().eq(":").any() if 1 in df.columns else False
+        if not is_pharmspec:
+            self._parse_hiac_run_counter_format(df)
+            return
+
         """
         Find the data in the raw dataframe. We identify the boundary of the data
         by finding the index first row which contains the word 'Particle' and ending right before


### PR DESCRIPTION
## Summary
- HIAC instruments can export the "Run Counter Test" format as `.xlsx`, not just `.xls`
- The `_read_xlsx` method assumed all `.xlsx` files use the PharmSpec format (which has an `Approver_` footer marker), causing `AllotropeConversionError` on HIAC Run Counter `.xlsx` files
- Added format detection: PharmSpec uses a 3-column header layout (`key` | `:` | `value`), while HIAC Run Counter uses a 2-column layout (`key` | `: value`). Routes to the existing `_parse_hiac_run_counter_format` handler when the file isn't PharmSpec.

## Test plan
- [x] All 17 existing beckman_pharmspec tests pass (including the `missing_approver` error test)
- [x] Verified the failing `.xlsx` HIAC file now parses successfully
- [x] Verified existing `.xls` HIAC files still parse correctly
- [x] Lint clean (ruff, black, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)