### PR TITLE
feat: Agilent OpenLab CDS - report signal description, total peak area and molar mass

### DIFF
--- a/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_structure.py
+++ b/src/allotropy/parsers/agilent_openlab_cds/agilent_openlab_cds_structure.py
@@ -117,6 +117,44 @@ def create_metadata(
     )
 
 
+def get_molar_mass_custom_info(peak: dict[str, Any]) -> dict[str, Any]:
+    """Reads the peak's molar mass results, which ASM has no native concept for.
+
+    Only reported for size-exclusion methods with a GPC calibration, so usually absent.
+    """
+    return {
+        key: {
+            "value": try_float_or_none(peak[element].get("@val")),
+            "unit": unit,
+        }
+        for element, (key, unit) in constants.PEAK_MOLAR_MASS_FIELDS.items()
+        if isinstance(peak.get(element), dict)
+    }
+
+
+def get_total_peak_area(peaks: list[Peak] | None) -> dict[str, Any] | None:
+    """Sums the peak areas reported for a signal.
+
+    Reported as custom information because a processed data document holds only a peak list. Summing
+    the vendor's areas needs no integration parameters of our own, unlike deriving them from the
+    chromatogram would.
+    """
+    areas = [
+        (peak.area, peak.area_unit) for peak in peaks or [] if peak.area is not None
+    ]
+    units = {unit for _, unit in areas}
+    # A signal comes from a single detector, so its areas share a unit. Don't sum if they somehow
+    # do not, as the total would be meaningless.
+    if not areas or len(units) != 1:
+        return None
+    return {
+        "total peak area": {
+            "value": sum(area for area, _ in areas),
+            "unit": units.pop(),
+        }
+    }
+
+
 def create_peak(peak_structure: list[dict[str, Any]]) -> list[Peak]:
     return [
         Peak(
@@ -180,6 +218,7 @@ def create_peak(peak_structure: list[dict[str, Any]]) -> list[Peak]:
             number_of_theoretical_plates__chromatography_=try_float_or_none(
                 peak.get("TheoreticalPlates_USP", {}).get("@val")
             ),
+            custom_info=get_molar_mass_custom_info(peak),
         )
         for peak in peak_structure
     ]
@@ -199,6 +238,11 @@ def create_measurements(
         None,
     )
     column_info = get_column_info(intermediate_structured_data)
+    peaks_by_measurement = {
+        i: create_peak(result_data["Peak"])
+        for i, result_data in enumerate(intermediate_structured_data["Result Data"])
+        if "Peak" in result_data
+    }
     return [
         Measurement(
             measurement_identifier=random_uuid_str(),
@@ -420,6 +464,14 @@ def create_measurements(
                         "signal"
                     ]
                     else None,
+                    # The signal name carries the detector settings the wavelength and bandwidth
+                    # fields above are read from, plus the reference setting, which is often "off"
+                    # and so has no numeric field to go in. Report it verbatim so nothing is lost.
+                    device_control_custom_info={
+                        "signal description": intermediate_structured_data[
+                            "Result Data"
+                        ][i]["Metadata"]["signal"]
+                    },
                 )
                 for module in intermediate_structured_data["Metadata"]["Instrument"][
                     "Module"
@@ -439,9 +491,8 @@ def create_measurements(
                     ]
                 )
             ],
-            peaks=create_peak(intermediate_structured_data["Result Data"][i]["Peak"])
-            if "Peak" in intermediate_structured_data["Result Data"][i]
-            else None,
+            peaks=peaks_by_measurement.get(i),
+            processed_data_custom_info=get_total_peak_area(peaks_by_measurement.get(i)),
             chromatogram_data_cube=create_data_cube(
                 label=f"{intermediate_structured_data['Result Data'][i]['Metadata']['signal'].split(',')[0]} chromatogram",
                 measures_value=intermediate_structured_data["Result Data"][i][

--- a/src/allotropy/parsers/agilent_openlab_cds/constants.py
+++ b/src/allotropy/parsers/agilent_openlab_cds/constants.py
@@ -10,3 +10,18 @@ SAMPLE_ROLE_TYPE = {
     "Blank": SampleRoleType.blank_role.value,
     "Sample": SampleRoleType.sample_role.value,
 }
+
+# Molar mass results OpenLab CDS reports per peak for size-exclusion (GPC) methods, mapped from the
+# result set element name to the custom information key and its unit. No ASM schema has a
+# molecular-weight concept, so these are reported as peak custom information.
+#
+# Only methods with a GPC calibration report them, so they are absent from result sets acquired with
+# a plain LC method. Element names follow the report column labels, as the other peak results do
+# (Area/AreaPercent/Height); confirm them against a GPC result set before relying on them.
+PEAK_MOLAR_MASS_FIELDS = {
+    "Mn": ("Mn", "g/mol"),
+    "Mw": ("Mw", "g/mol"),
+    "Mp": ("Mp", "g/mol"),
+    "Mz": ("Mz", "g/mol"),
+    "PD": ("polydispersity", "(unitless)"),
+}

--- a/tests/parsers/agilent_openlab_cds/agilent_openlab_cds_structure_test.py
+++ b/tests/parsers/agilent_openlab_cds/agilent_openlab_cds_structure_test.py
@@ -1,0 +1,78 @@
+"""Tests for OpenLab CDS peak results that the test data files do not cover.
+
+Molar mass results are only reported for size-exclusion methods with a GPC calibration, and no
+result set we have was acquired with one, so they are covered here from peak data directly.
+"""
+from typing import Any
+
+import pytest
+
+from allotropy.allotrope.schema_mappers.adm.liquid_chromatography.benchling._2023._09.liquid_chromatography import (
+    Peak,
+)
+from allotropy.parsers.agilent_openlab_cds.agilent_openlab_cds_structure import (
+    create_peak,
+    get_total_peak_area,
+)
+
+
+def _peak(**elements: Any) -> dict[str, Any]:
+    return {
+        "@id": "peak-1",
+        "RetentionTime": {"@val": "2.5", "@unit": "min"},
+        "Area": {"@val": "2761.5", "@unit": "mAU·s"},
+        "AreaPercent": {"@val": "27.7"},
+        "Height": {"@val": "123.2", "@unit": "mAU"},
+        "BeginTime": {"@val": "2.35", "@unit": "min"},
+        "EndTime": {"@val": "2.81", "@unit": "min"},
+        **elements,
+    }
+
+
+def test_peak_reports_molar_mass_results() -> None:
+    (peak,) = create_peak(
+        [
+            _peak(
+                Mn={"@val": "148532.0"},
+                Mw={"@val": "151203.5"},
+                PD={"@val": "1.018"},
+            )
+        ]
+    )
+    assert peak.custom_info == {
+        "Mn": {"value": 148532.0, "unit": "g/mol"},
+        "Mw": {"value": 151203.5, "unit": "g/mol"},
+        "polydispersity": {"value": 1.018, "unit": "(unitless)"},
+    }
+
+
+def test_peak_without_molar_mass_results_reports_none() -> None:
+    (peak,) = create_peak([_peak()])
+    assert peak.custom_info == {}
+
+
+def test_total_peak_area_sums_areas() -> None:
+    peaks = create_peak(
+        [
+            _peak(Area={"@val": "100.5", "@unit": "mAU·s"}),
+            _peak(Area={"@val": "200.25", "@unit": "mAU·s"}),
+        ]
+    )
+    assert get_total_peak_area(peaks) == {
+        "total peak area": {"value": 300.75, "unit": "mAU.s"}
+    }
+
+
+@pytest.mark.parametrize("peaks", [None, [], [Peak(identifier="peak-1")]])
+def test_total_peak_area_without_areas_is_not_reported(
+    peaks: list[Peak] | None,
+) -> None:
+    assert get_total_peak_area(peaks) is None
+
+
+def test_total_peak_area_of_mixed_units_is_not_reported() -> None:
+    peaks = [
+        Peak(identifier="peak-1", area=100.0, area_unit="mAU.s"),
+        Peak(identifier="peak-2", area=200.0, area_unit="RFU.s"),
+    ]
+    assert get_total_peak_area(peaks) is None

--- a/tests/parsers/agilent_openlab_cds/testdata/Luxo HPLC-2023-09-01 07-52-44-04-00.json
+++ b/tests/parsers/agilent_openlab_cds/testdata/Luxo HPLC-2023-09-01 07-52-44-04-00.json
@@ -63,6 +63,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -656,7 +659,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_1"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_1",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 7921.543156895651,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -724,6 +733,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -1176,7 +1188,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_3"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_3",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 35335.0659913903,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -1244,6 +1262,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -1872,7 +1893,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_5"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_5",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 9967.199418961032,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -1937,6 +1964,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -2424,7 +2454,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_7"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_7",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 3296.841759710523,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -2487,6 +2523,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -2764,7 +2803,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_9"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_9",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 1494.043820791225,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -2898,6 +2943,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -3175,7 +3223,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_13"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_13",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 7270.419489977856,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -3385,6 +3439,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -3838,7 +3895,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_19"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_19",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 4877.537680538353,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -3906,6 +3969,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -4218,7 +4284,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_21"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_21",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 3279.201962639718,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -4351,6 +4423,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -4978,7 +5053,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_25"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_25",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 17610.692942072335,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -5046,6 +5127,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -5569,7 +5653,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_27"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_27",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 8176.706979125323,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -5703,6 +5793,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -6296,7 +6389,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_31"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_31",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 6215.6720649422405,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -6575,6 +6674,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -7063,7 +7165,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_39"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_39",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 9468.805021391407,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -7126,6 +7234,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -7439,7 +7550,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_41"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_41",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 4016.864153451461,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -7502,6 +7619,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -7920,7 +8040,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_43"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_43",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 4865.423699477294,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -7983,6 +8109,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -8296,7 +8425,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_45"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_45",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 4544.04968984369,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -8359,6 +8494,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -9021,7 +9159,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_47"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_47",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 10329.619989101835,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -9084,6 +9228,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -9432,7 +9579,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_49"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_49",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 3644.8977503261385,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -9500,6 +9653,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -9918,7 +10074,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_51"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_51",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 5818.56489016171,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -10054,6 +10216,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -10366,7 +10531,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_55"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_55",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 14612.92573007797,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -10434,6 +10605,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -11027,7 +11201,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_57"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_57",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 6383.642773743148,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },

--- a/tests/parsers/agilent_openlab_cds/testdata/Sirius-2023-09-01 07-52-44-04-00.json
+++ b/tests/parsers/agilent_openlab_cds/testdata/Sirius-2023-09-01 07-52-44-04-00.json
@@ -62,6 +62,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -690,7 +693,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_1"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_1",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 9967.199418961032,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -755,6 +764,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1B,Sig=210,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -1242,7 +1254,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_3"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_3",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 3296.841759710523,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -1305,6 +1323,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -1582,7 +1603,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_5"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_5",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 1494.043820791225,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -1786,6 +1813,9 @@
                                         "detector bandwidth setting": {
                                             "value": 4.0,
                                             "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "signal description": "DAD1D,Sig=228,4  Ref=360,100"
                                         }
                                     }
                                 ]
@@ -2099,7 +2129,13 @@
                                                 }
                                             ]
                                         },
-                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_11"
+                                        "processed data identifier": "AGILENT_OPENLAB_CDS_TEST_ID_11",
+                                        "custom information document": {
+                                            "total peak area": {
+                                                "value": 4544.04968984369,
+                                                "unit": "mAU.s"
+                                            }
+                                        }
                                     }
                                 ]
                             },


### PR DESCRIPTION
## Summary

A customer reviewing Agilent OpenLab CDS output asked for five fields from their *Sequence Summary with GPC* report. Three were already emitted — **Sample Name** (`sample identifier`), **RT [min]** (`retention time`, in seconds) and **Area (%)** (`relative peak area`). Their result set simply had no peaks in it, having been exported before data analysis was run. This PR adds homes for the other two, plus the total area their report also sums:

| Report field | Where it now lands |
|---|---|
| Signal Description | `device control document` → custom information → `signal description` |
| *Sum* of Area | `processed data document` → custom information → `total peak area` |
| Mn (g/mol) | `peak` → custom information → `Mn` (also `Mw`, `Mp`, `Mz`, `polydispersity`) |

### Signal description

The signal name (`DAD1B,Sig=210,4  Ref=360,100`) is the report's Signal Description. Only its leading token survived, as the chromatogram data cube label. `detector wavelength setting` and `detector bandwidth setting` are already parsed out of it, but the reference setting is not — and it is sometimes `Ref=off`, so it has no numeric field to go in. Reporting the name verbatim keeps everything without inventing a parse.

### Total peak area

Summed per signal. A `processed data document` holds only a `peak list`, so there is no native slot. Summing the vendor's own areas needs no integration parameters of ours, unlike deriving areas from the chromatogram would — that would mean inventing peak-detection and baseline parameters belonging to the vendor's data analysis method. Not summed if the areas somehow disagree on unit.

### Molar mass

No ASM schema has a molecular-weight concept — `"molar mass"` appears only in the `statistical feature` enum of `statisticsAggregateDocument`, whose `statistics document` has no slot for a value and never attaches to a peak. So these go in the peak's custom information document, which the LC peak schema permits (no `additionalProperties: false`).

**Only size-exclusion methods with a GPC calibration report them**, and neither test file was acquired with one, so they are covered by unit tests over peak data rather than by a result set. The element names are declared in one constant, `PEAK_MOLAR_MASS_FIELDS`, and follow the report column labels as the other peak results do (`Area`/`AreaPercent`/`Height`) — they should be confirmed against a real GPC result set, which is a one-line change to that constant. This is the same shape as the existing speculative reads in `create_peak` (`Resolution_USP`, `Width_50Perc`, `TheoreticalPlates_USP`), none of which appear in either test file either.

## Test data changes

Both expected outputs gain the `signal description` and `total peak area` custom information documents. **No existing value changed** — the only removed lines are trailing-comma reflow, and the mocked identifiers are unchanged. Verified that every measurement with peaks got a total equal to `sum(peak area)` (20/20 and 4/4), that pump device control documents were not tagged, and that no peak custom information is emitted for these files.

## Testing

- `hatch run test_all.py3.10:pytest tests/` — 1497 passed
- `hatch run lint` — clean (792 files black, 789 mypy)
- New `agilent_openlab_cds_structure_test.py` — 7 tests covering the molar mass path, the area sum, and the no-area / mixed-unit cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
